### PR TITLE
Static Files Plugin

### DIFF
--- a/src/main/kotlin/io/kweb/plugins/staticFiles/StaticFilesPlugin.kt
+++ b/src/main/kotlin/io/kweb/plugins/staticFiles/StaticFilesPlugin.kt
@@ -1,0 +1,29 @@
+package io.kweb.plugins.staticFiles
+
+import io.ktor.http.content.files
+import io.ktor.http.content.static
+import io.ktor.http.content.staticRootFolder
+import io.ktor.routing.Routing
+import io.kweb.plugins.KwebPlugin
+import java.io.File
+
+/**
+ * @author rpanic
+ *
+ * This Plugin serves static files to be used in the frontend
+ *
+ * @property rootFolder The root folder, where the static assets are saved
+ * @property servedRoute The route where these assets are being served
+ */
+class StaticFilesPlugin(private val rootFolder: File, private val servedRoute: String = "assets") : KwebPlugin(){
+
+    override fun decorate(startHead: StringBuilder, endHead: StringBuilder){}
+
+    override fun appServerConfigurator(routeHandler: Routing) {
+        routeHandler.static(servedRoute){
+            staticRootFolder = rootFolder
+            files(".")
+        }
+    }
+
+}


### PR DESCRIPTION
I created a small plugin which enables a Kweb application to serve static Files to the frontend.
You can use it like this:
`plugins = listOf(StaticFilesPlugin(rootFolder = File(System.getProperty("user.dir") + "/src/main/resources"), servedRoute = "assets"))`

You can specify the root folder from where the files get pulled and the route where they should be made accessible