### PR TITLE
Create extensions to use Kweb as Ktor response

### DIFF
--- a/src/main/kotlin/kweb/KtorFeature.kt
+++ b/src/main/kotlin/kweb/KtorFeature.kt
@@ -6,6 +6,7 @@ import io.ktor.application.call
 import io.ktor.application.feature
 import io.ktor.routing.get
 import io.ktor.routing.routing
+import kweb.routing.PathReceiver
 
 /**
  * Kweb normally calls this function on initialization, if you provide a buildpage,
@@ -13,8 +14,10 @@ import io.ktor.routing.routing
  *
  * If you are using Ktor, this is an easy way to migrate from the deprecated buildPage design
  *
- * Kweb will still do its internal routing properly, e.g if you use `path()` in your buildPage,
- * but it will also respect Ktor defined routes ^-^
+ * Kweb will still do its internal routing properly, e.g if you use `path()` in your buildPage. ^-^
+ *
+ * Nevertheless, please be very careful and avoid using both models in parallel as they
+ * have lots of subtle differences and you're bound to hit something!
  */
 fun Application.installKwebOnRemainingRoutes(buildPage: WebBrowser.() -> Unit) {
     routing {
@@ -33,12 +36,28 @@ suspend fun ApplicationCall.respondKweb(buildPage: WebBrowser.() -> Unit) =
     application.feature(Kweb).respondKweb(this, buildPage)
 
 /**
+ * If you were previously using Kweb routes and you want to switch to Ktor, this is for you.
+ * You can copy your previous path receivers and they will be run the same way as before,
+ *
+ * EXCEPT FOR THE PARAMETERS
+ *
+ * Note that parameter handling is no longer done by Kweb, you'll have to use the Ktor
+ * [io.ktor.http.Parameters] functions
+ *
+ * @param pathReceiver the receiver to execute on this path
+ */
+suspend fun ApplicationCall.respondKwebRender(pathReceiver: PathReceiver) =
+    respondKweb {
+        doc.body.new { span().new { pathReceiver(this, emptyMap()) } }
+    }
+
+/**
  * Use this if you are on Ktor and migrating out of the deprecated buildPage design
  */
 const val buildPageReplacementCode = """
     routing {
         get("/{visitedUrl...}") {
-            call.respondKweb { 
+            call.respondKwebRender { 
                 buildPage
             }
         }

--- a/src/main/kotlin/kweb/KtorFeature.kt
+++ b/src/main/kotlin/kweb/KtorFeature.kt
@@ -1,0 +1,46 @@
+package kweb
+
+import io.ktor.application.Application
+import io.ktor.application.ApplicationCall
+import io.ktor.application.call
+import io.ktor.application.feature
+import io.ktor.routing.get
+import io.ktor.routing.routing
+
+/**
+ * Kweb normally calls this function on initialization, if you provide a buildpage,
+ * regardless of whether it's initialized as a standalone, or Ktor Feature.
+ *
+ * If you are using Ktor, this is an easy way to migrate from the deprecated buildPage design
+ *
+ * Kweb will still do its internal routing properly, e.g if you use `path()` in your buildPage,
+ * but it will also respect Ktor defined routes ^-^
+ */
+fun Application.installKwebOnRemainingRoutes(buildPage: WebBrowser.() -> Unit) {
+    routing {
+        get("/{visitedUrl...}") {
+            call.respondKweb(buildPage)
+        }
+    }
+}
+
+/**
+ * Allows for defining Kweb responses inlined in Ktor routing code
+ *
+ * @see kweb.demos.feature.kwebFeature
+ */
+suspend fun ApplicationCall.respondKweb(buildPage: WebBrowser.() -> Unit) =
+    application.feature(Kweb).respondKweb(this, buildPage)
+
+/**
+ * Use this if you are on Ktor and migrating out of the deprecated buildPage design
+ */
+const val buildPageReplacementCode = """
+    routing {
+        get("/{visitedUrl...}") {
+            call.respondKweb { 
+                buildPage
+            }
+        }
+    }
+    """

--- a/src/main/kotlin/kweb/Kweb.kt
+++ b/src/main/kotlin/kweb/Kweb.kt
@@ -256,9 +256,12 @@ class Kweb private constructor(
                 call.respondText("favicons not currently supported by kweb")
             }
 
+            get("/{visitedUrl...}") {
+                respondKweb(call, buildPage)
+            }
+
         }
 
-        application.installKwebOnRemainingRoutes(buildPage)
         installRequiredKwebComponents(application)
     }
 

--- a/src/main/kotlin/kweb/Kweb.kt
+++ b/src/main/kotlin/kweb/Kweb.kt
@@ -2,13 +2,16 @@ package kweb
 
 import com.github.salomonbrys.kotson.fromJson
 import io.ktor.application.Application
+import io.ktor.application.ApplicationCall
 import io.ktor.application.ApplicationFeature
 import io.ktor.application.call
+import io.ktor.application.feature
 import io.ktor.application.install
 import io.ktor.features.Compression
 import io.ktor.features.DefaultHeaders
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.cio.websocket.DefaultWebSocketSession
 import io.ktor.http.cio.websocket.Frame.Text
 import io.ktor.http.cio.websocket.pingPeriod
 import io.ktor.http.cio.websocket.readText
@@ -25,6 +28,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.jetty.Jetty
 import io.ktor.server.jetty.JettyApplicationEngine
 import io.ktor.util.AttributeKey
+import io.ktor.util.pipeline.PipelineContext
 import io.ktor.websocket.WebSockets
 import io.ktor.websocket.webSocket
 import kotlinx.coroutines.Dispatchers
@@ -53,8 +57,7 @@ private val CLIENT_STATE_TIMEOUT: Duration = Duration.ofHours(48)
 
 class Kweb private constructor(
         val debug: Boolean,
-        val plugins: List<KwebPlugin>,
-        val buildPage: WebBrowser.() -> Unit
+        val plugins: List<KwebPlugin>
 ) : Closeable {
 
     /**
@@ -76,14 +79,14 @@ class Kweb private constructor(
             plugins: List<KwebPlugin> = Collections.emptyList(),
             httpsConfig: EngineSSLConnectorConfig? = null,
             buildPage: WebBrowser.() -> Unit
-    ) : this(debug, plugins, buildPage) {
+    ) : this(debug, plugins) {
         logger.info("Initializing Kweb listening on port $port")
 
         if (debug) {
             logger.warn("Debug mode enabled, if in production use KWeb(debug = false)")
         }
 
-        server = createServer(port, httpsConfig)
+        server = createServer(port, httpsConfig, buildPage)
 
         server!!.start()
         logger.info { "KWeb is listening on port $port" }
@@ -114,15 +117,14 @@ class Kweb private constructor(
         class Configuration {
             var debug: Boolean = true
             var plugins: List<KwebPlugin> = Collections.emptyList()
-            lateinit var buildPage: WebBrowser.() -> Unit
         }
 
         override val key = AttributeKey<Kweb>("Kweb")
 
         override fun install(pipeline: Application, configure: Configuration.() -> Unit): Kweb {
             val configuration = Configuration().apply(configure)
-            val feature = Kweb(configuration.debug, configuration.plugins, configuration.buildPage)
-            feature.setupKweb(pipeline)
+            val feature = Kweb(configuration.debug, configuration.plugins)
+            feature.installRequiredKwebComponents(pipeline)
             return feature
         }
     }
@@ -218,7 +220,7 @@ class Kweb private constructor(
         server?.stop(0, 0)
     }
 
-    private fun createServer(port: Int, httpsConfig: EngineSSLConnectorConfig?): JettyApplicationEngine {
+    private fun createServer(port: Int, httpsConfig: EngineSSLConnectorConfig?, buildPage: WebBrowser.() -> Unit): JettyApplicationEngine {
         return embeddedServer(Jetty, applicationEngineEnvironment {
             this.module {
                 install(DefaultHeaders)
@@ -228,7 +230,7 @@ class Kweb private constructor(
                     timeout = Duration.ofSeconds(30)
                 }
 
-                setupKweb(this)
+                setupKweb(this, buildPage)
             }
 
             connector {
@@ -241,11 +243,9 @@ class Kweb private constructor(
         })
     }
 
-    private fun setupKweb(application: Application) {
+    private fun setupKweb(application: Application, buildPage: WebBrowser.() -> Unit) {
 
         application.routing {
-
-            val htmlDocumentSupplier = createHtmlDocumentSupplier()
 
             get("/robots.txt") {
                 call.response.status(HttpStatusCode.NotFound)
@@ -257,10 +257,19 @@ class Kweb private constructor(
                 call.respondText("favicons not currently supported by kweb")
             }
 
-            // It's important to use a clone of the template because the result will be modified
-            listenForHTTPConnection(htmlDocumentSupplier.invoke())
 
-            listenForWebsocketConnection()
+            get("/{visitedUrl...}") {
+                respondKweb(call, buildPage)
+            }
+        }
+        installRequiredKwebComponents(application)
+    }
+
+    private fun installRequiredKwebComponents(application: Application) {
+        application.routing {
+            webSocket("/ws") {
+                listenForWebsocketConnection()
+            }
         }
 
         GlobalScope.launch {
@@ -271,7 +280,18 @@ class Kweb private constructor(
         }
     }
 
-    private fun Routing.createHtmlDocumentSupplier(): () -> Document {
+    suspend fun respondKweb(pipelineContext: ApplicationCall, buildPage: WebBrowser.() -> Unit) {
+        val htmlDocument = createHtmlDocumentSupplier().invoke()
+
+        // It's important to use a clone of the template because the result will be modified
+        for (plugin in plugins) {
+            applyPluginWithDependencies(plugin = plugin, appliedPlugins = mutableAppliedPlugins, document = htmlDocument.clone(), routeHandler = pipelineContext.application.routing {  })
+        }
+
+        pipelineContext.listenForHTTPConnection(htmlDocument.clone(), buildPage)
+    }
+
+    private fun createHtmlDocumentSupplier(): () -> Document {
         val docTemplate = Document("") // TODO: What should this base URL be?
 
         docTemplate.appendChild(DocumentType("html", "", ""))
@@ -295,103 +315,86 @@ class Kweb private constructor(
                             | requires JavaScript to be enabled.""".trimMargin())
             }
         }
-        for (plugin in plugins) {
-            applyPluginWithDependencies(plugin = plugin, appliedPlugins = mutableAppliedPlugins, document = docTemplate, routeHandler = this)
-        }
 
         return { docTemplate.clone() }
     }
 
-    private fun Routing.listenForWebsocketConnection(path: String = "/ws") {
-        webSocket(path) {
+    private suspend fun DefaultWebSocketSession.listenForWebsocketConnection() {
+        val hello = gson.fromJson<Client2ServerMessage>(((incoming.receive() as Text).readText()))
 
-            val hello = gson.fromJson<Client2ServerMessage>(((incoming.receive() as Text).readText()))
+        if (hello.hello == null) {
+            error("First message from client isn't 'hello'")
+        }
 
-            if (hello.hello == null) {
-                error("First message from client isn't 'hello'")
-            }
+        val remoteClientState = clientState.get(hello.id)
+                ?: error("Unable to find server state corresponding to client id ${hello.id}")
 
-            val remoteClientState = clientState.get(hello.id)
-                    ?: error("Unable to find server state corresponding to client id ${hello.id}")
-
-            assert(remoteClientState.clientConnection is Caching)
-            logger.debug { "Received message from remoteClient ${remoteClientState.id}, flushing outbound message cache" }
-            val cachedConnection = remoteClientState.clientConnection as Caching
-            val webSocketClientConnection = ClientConnection.WebSocket(this)
-            remoteClientState.clientConnection = webSocketClientConnection
-            logger.debug { "Set clientConnection for ${remoteClientState.id} to WebSocket, sending ${cachedConnection.size} cached messages" }
-            cachedConnection.read().forEach { webSocketClientConnection.send(it) }
+        assert(remoteClientState.clientConnection is Caching)
+        logger.debug { "Received message from remoteClient ${remoteClientState.id}, flushing outbound message cache" }
+        val cachedConnection = remoteClientState.clientConnection as Caching
+        val webSocketClientConnection = ClientConnection.WebSocket(this)
+        remoteClientState.clientConnection = webSocketClientConnection
+        logger.debug { "Set clientConnection for ${remoteClientState.id} to WebSocket, sending ${cachedConnection.size} cached messages" }
+        cachedConnection.read().forEach { webSocketClientConnection.send(it) }
 
 
-            try {
-                for (frame in incoming) {
-                    try {
-                        logger.debug { "Message received from client" }
+        try {
+            for (frame in incoming) {
+                try {
+                    logger.debug { "Message received from client" }
 
-                        if (frame is Text) {
-                            val message = gson.fromJson<Client2ServerMessage>(frame.readText())
-                            logger.debug { "Message received: $message" }
-                            if (message.error != null) {
-                                handleError(message.error, remoteClientState)
-                            } else {
-                                when {
-                                    message.callback != null -> {
-                                        val (resultId, result) = message.callback
-                                        val resultHandler = remoteClientState.handlers[resultId]
-                                                ?: error("No data handler for $resultId for client ${remoteClientState.id}")
-                                        resultHandler(result ?: "")
-                                    }
-                                    message.historyStateChange != null -> {
+                    if (frame is Text) {
+                        val message = gson.fromJson<Client2ServerMessage>(frame.readText())
+                        logger.debug { "Message received: $message" }
+                        if (message.error != null) {
+                            handleError(message.error, remoteClientState)
+                        } else {
+                            when {
+                                message.callback != null -> {
+                                    val (resultId, result) = message.callback
+                                    val resultHandler = remoteClientState.handlers[resultId]
+                                            ?: error("No data handler for $resultId for client ${remoteClientState.id}")
+                                    resultHandler(result ?: "")
+                                }
+                                message.historyStateChange != null -> {
 
-                                    }
                                 }
                             }
                         }
-                    } catch (e: Exception) {
-                        logger.error("Exception while receiving websocket message", e)
                     }
+                } catch (e: Exception) {
+                    logger.error("Exception while receiving websocket message", e)
                 }
-            } finally {
-                logger.info("WS session disconnected for client id: ${remoteClientState.id}")
-                remoteClientState.clientConnection = Caching()
             }
+        } finally {
+            logger.info("WS session disconnected for client id: ${remoteClientState.id}")
+            remoteClientState.clientConnection = Caching()
         }
     }
 
-    private fun Routing.listenForHTTPConnection(htmlDocumentTemplate: Document) {
-        get("/{visitedUrl...}") {
-            val htmlDocument = htmlDocumentTemplate.clone()
+    private suspend fun ApplicationCall.listenForHTTPConnection(htmlDocument: Document, buildPage: WebBrowser.() -> Unit) {
+        val kwebSessionId = createNonce()
 
-            val kwebSessionId = createNonce()
+        val remoteClientState = clientState.getOrPut(kwebSessionId) {
+            RemoteClientState(id = kwebSessionId, clientConnection = Caching())
+        }
 
-            val remoteClientState = clientState.getOrPut(kwebSessionId) {
-                RemoteClientState(id = kwebSessionId, clientConnection = Caching())
-            }
+        val httpRequestInfo = HttpRequestInfo(request)
 
-            val httpRequestInfo = HttpRequestInfo(call.request)
+        try {
+            val webBrowser = WebBrowser(kwebSessionId, httpRequestInfo, this@Kweb)
+            webBrowser.htmlDocument.set(htmlDocument)
+            if (debug) {
+                warnIfBlocking(maxTimeMs = MAX_PAGE_BUILD_TIME.toMillis(), onBlock = { thread ->
+                    logger.warn { "buildPage lambda must return immediately but has taken > $MAX_PAGE_BUILD_TIME.  More info at DEBUG loglevel" }
 
-            try {
-                val webBrowser = WebBrowser(kwebSessionId, httpRequestInfo, this@Kweb)
-                webBrowser.htmlDocument.set(htmlDocument)
-                if (debug) {
-                    warnIfBlocking(maxTimeMs = MAX_PAGE_BUILD_TIME.toMillis(), onBlock = { thread ->
-                        logger.warn { "buildPage lambda must return immediately but has taken > $MAX_PAGE_BUILD_TIME.  More info at DEBUG loglevel" }
+                    val logStatementBuilder = StringBuilder()
+                    logStatementBuilder.appendln("buildPage lambda must return immediately but has taken > $MAX_PAGE_BUILD_TIME, appears to be blocking here:")
 
-                        val logStatementBuilder = StringBuilder()
-                        logStatementBuilder.appendln("buildPage lambda must return immediately but has taken > $MAX_PAGE_BUILD_TIME, appears to be blocking here:")
-
-                        thread.stackTrace.pruneAndDumpStackTo(logStatementBuilder)
-                        val logStatement = logStatementBuilder.toString()
-                        logger.debug { logStatement }
-                    }) {
-                        try {
-                            buildPage(webBrowser)
-                        } catch (e: Exception) {
-                            logger.error("Exception thrown building page", e)
-                        }
-                        logger.debug { "Outbound message queue size after buildPage is ${(remoteClientState.clientConnection as Caching).queueSize()}" }
-                    }
-                } else {
+                    thread.stackTrace.pruneAndDumpStackTo(logStatementBuilder)
+                    val logStatement = logStatementBuilder.toString()
+                    logger.debug { logStatement }
+                }) {
                     try {
                         buildPage(webBrowser)
                     } catch (e: Exception) {
@@ -399,43 +402,50 @@ class Kweb private constructor(
                     }
                     logger.debug { "Outbound message queue size after buildPage is ${(remoteClientState.clientConnection as Caching).queueSize()}" }
                 }
-                for (plugin in plugins) {
-                    execute(kwebSessionId, plugin.executeAfterPageCreation())
+            } else {
+                try {
+                    buildPage(webBrowser)
+                } catch (e: Exception) {
+                    logger.error("Exception thrown building page", e)
                 }
-
-                webBrowser.htmlDocument.set(null) // Don't think this webBrowser will be used again, but not going to risk it
-
-                val initialCachedMessages = remoteClientState.clientConnection as Caching
-
-                remoteClientState.clientConnection = Caching()
-
-                val bootstrapJS = BootstrapJs.hydrate(
-                        kwebSessionId,
-                        initialCachedMessages
-                                .read().joinToString(separator = "\n") { "handleInboundMessage($it);" })
-
-                htmlDocument.head().appendElement("script")
-                        .attr("language", "JavaScript")
-                        .appendChild(DataNode(bootstrapJS))
-                htmlDocument.outputSettings().prettyPrint(debug)
-
-
-                call.respondText(htmlDocument.outerHtml(), ContentType.Text.Html)
-            } catch (nfe: NotFoundException) {
-                call.response.status(HttpStatusCode.NotFound)
-                call.respondText("URL ${call.request.uri} not found.", ContentType.parse("text/plain"))
-            } catch (e: Exception) {
-                val logToken = random.nextLong().toString(16)
-
-                logger.error(e) { "Exception thrown while rendering page, code $logToken" }
-
-                call.response.status(HttpStatusCode.InternalServerError)
-                call.respondText("""
-                            Internal Server Error.
-
-                            Please include code $logToken in any error report to help us track it down.
-    """.trimIndent())
+                logger.debug { "Outbound message queue size after buildPage is ${(remoteClientState.clientConnection as Caching).queueSize()}" }
             }
+            for (plugin in plugins) {
+                execute(kwebSessionId, plugin.executeAfterPageCreation())
+            }
+
+            webBrowser.htmlDocument.set(null) // Don't think this webBrowser will be used again, but not going to risk it
+
+            val initialCachedMessages = remoteClientState.clientConnection as Caching
+
+            remoteClientState.clientConnection = Caching()
+
+            val bootstrapJS = BootstrapJs.hydrate(
+                    kwebSessionId,
+                    initialCachedMessages
+                            .read().joinToString(separator = "\n") { "handleInboundMessage($it);" })
+
+            htmlDocument.head().appendElement("script")
+                    .attr("language", "JavaScript")
+                    .appendChild(DataNode(bootstrapJS))
+            htmlDocument.outputSettings().prettyPrint(debug)
+
+
+            respondText(htmlDocument.outerHtml(), ContentType.Text.Html)
+        } catch (nfe: NotFoundException) {
+            response.status(HttpStatusCode.NotFound)
+            respondText("URL ${request.uri} not found.", ContentType.parse("text/plain"))
+        } catch (e: Exception) {
+            val logToken = random.nextLong().toString(16)
+
+            logger.error(e) { "Exception thrown while rendering page, code $logToken" }
+
+            response.status(HttpStatusCode.InternalServerError)
+            respondText("""
+                        Internal Server Error.
+
+                        Please include code $logToken in any error report to help us track it down.
+""".trimIndent())
         }
     }
 
@@ -508,5 +518,13 @@ class Kweb private constructor(
     }
 
 }
+
+/**
+ * Allows for defining Kweb responses inlined in Ktor routing code
+ *
+ * @see kweb.demos.feature.kwebFeature
+ */
+suspend fun ApplicationCall.respondKweb(buildPage: WebBrowser.() -> Unit) =
+    application.feature(Kweb).respondKweb(this, buildPage)
 
 data class DebugInfo(val js: String, val action: String, val throwable: Throwable)

--- a/src/main/kotlin/kweb/WebBrowser.kt
+++ b/src/main/kotlin/kweb/WebBrowser.kt
@@ -4,6 +4,7 @@ import io.mola.galimatias.URL
 import kweb.client.HttpRequestInfo
 import kweb.client.Server2ClientMessage.Instruction
 import kweb.html.Document
+import kweb.html.HtmlDocumentSupplier
 import kweb.plugins.KwebPlugin
 import kweb.state.KVar
 import kweb.state.ReversibleFunction
@@ -39,7 +40,7 @@ class WebBrowser(private val sessionId: String, val httpRequestInfo: HttpRequest
     fun generateId(): String = idCounter.getAndIncrement().toString(36)
 
     private val plugins: Map<KClass<out KwebPlugin>, KwebPlugin> by lazy {
-        kweb.appliedPlugins.map { it::class to it }.toMap()
+        HtmlDocumentSupplier.appliedPlugins.map { it::class to it }.toMap()
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/kweb/demos/feature/FeatureApp.kt
+++ b/src/main/kotlin/kweb/demos/feature/FeatureApp.kt
@@ -1,11 +1,15 @@
 package kweb.demos.feature
 
 import io.ktor.application.Application
+import io.ktor.application.call
 import io.ktor.application.install
 import io.ktor.features.Compression
 import io.ktor.features.DefaultHeaders
 import io.ktor.http.cio.websocket.pingPeriod
 import io.ktor.http.cio.websocket.timeout
+import io.ktor.response.respond
+import io.ktor.routing.get
+import io.ktor.routing.routing
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.jetty.Jetty
 import io.ktor.websocket.WebSockets
@@ -24,20 +28,34 @@ private fun Application.kwebFeature() {
         pingPeriod = Duration.ofSeconds(10)
         timeout = Duration.ofSeconds(30)
     }
+    install(Kweb)
 
-    install(Kweb) {
-        buildPage = {
-            doc.body.new {
-                val path = gurl.path
-                val greeting = path.map { it.removePrefix("/") }.map { "Hello " + if (it.isNotBlank()) it else "World" }
+    routing {
+        get("/kweb") {
+            call.respondKweb {
+                doc.body.new {
+                    val path = gurl.path
+                    val greeting = path.map { it.removePrefix("/") }.map { "Hello " + if (it.isNotBlank()) it else "World" }
 
-                val next = KVar("")
+                    val next = KVar("")
 
-                h1().text(greeting)
-                span().text("Where to next?")
-                input().setValue(next)
-                button().text("Go!").on.click {
-                    path.value = next.value
+                    h1().text(greeting)
+                    span().text("Where to next?")
+                    input().setValue(next)
+                    button().text("Go!").on.click {
+                        path.value = next.value
+                    }
+                }
+            }
+        }
+        get("/noweb") {
+            call.respond("Hello old world")
+        }
+        get("/otherKweb/{listId}") {
+            call.respondKweb {
+                doc.body.new {
+                    val param = call.parameters["listId"]
+                    h1().text("Hello from the other siiiiiiiidde! $param")
                 }
             }
         }

--- a/src/main/kotlin/kweb/html/HtmlDocumentSupplier.kt
+++ b/src/main/kotlin/kweb/html/HtmlDocumentSupplier.kt
@@ -1,0 +1,71 @@
+package kweb.html
+
+import io.ktor.routing.Routing
+import kweb.plugins.KwebPlugin
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.DocumentType
+import org.jsoup.nodes.Element
+import java.util.HashSet
+
+internal object HtmlDocumentSupplier {
+    val appliedPlugins: Set<KwebPlugin> get() = mutableAppliedPlugins
+
+    private val mutableAppliedPlugins: MutableSet<KwebPlugin> = HashSet()
+    private lateinit var docTemplate: Document
+
+    fun createDocTemplate(plugins: List<KwebPlugin>, routing: Routing) {
+        docTemplate = Document("") // TODO: What should this base URL be?
+
+        docTemplate.appendChild(DocumentType("html", "", ""))
+
+        docTemplate.appendElement("html").let { html: Element ->
+
+            html.appendElement("head").let { head: Element ->
+
+                head.appendElement("meta")
+                    .attr("name", "viewport")
+                    .attr("content", "width=device-width, initial-scale=1.0")
+            }
+
+            html.appendElement("body").let { body: Element ->
+
+                body.attr("onload", "buildPage()")
+                body.appendElement("noscript")
+                    .html(
+                        """
+                            | This page is built with <a href="https://kweb.io/">Kweb</a>, which 
+                            | requires JavaScript to be enabled.""".trimMargin())
+            }
+        }
+
+        for (plugin in plugins) {
+            // The document will be modified here!
+            applyPluginWithDependencies(plugin = plugin, appliedPlugins = mutableAppliedPlugins, document = docTemplate, routeHandler = routing)
+        }
+    }
+
+    /**
+     * The base template for pages
+     */
+    fun getTemplateCopy() =
+        docTemplate.clone()
+
+    private fun applyPluginWithDependencies(
+        plugin: KwebPlugin,
+        appliedPlugins: MutableSet<KwebPlugin>,
+        routeHandler: Routing,
+        document: Document
+    ) {
+        for (dependantPlugin in plugin.dependsOn) {
+            if (!appliedPlugins.contains(dependantPlugin)) {
+                applyPluginWithDependencies(dependantPlugin, appliedPlugins, routeHandler, document)
+                appliedPlugins.add(dependantPlugin)
+            }
+        }
+        if (!appliedPlugins.contains(plugin)) {
+            plugin.decorate(document)
+            plugin.appServerConfigurator(routeHandler)
+            appliedPlugins.add(plugin)
+        }
+    }
+}

--- a/src/main/kotlin/kweb/routing/routing.kt
+++ b/src/main/kotlin/kweb/routing/routing.kt
@@ -11,8 +11,6 @@ import mu.KotlinLogging
 
 // TODO: Handle back button https://www.webdesignerdepot.com/2013/03/how-to-manage-the-back-button-with-javascript/
 
-private val logger = KotlinLogging.logger {}
-
 typealias PathTemplate = List<RoutingPathSegment>
 typealias PathReceiver = ElementCreator<*>.(params: Map<String, KVar<String>>) -> Unit
 typealias NotFoundReceiver = (ElementCreator<*>).(path: String) -> Unit


### PR DESCRIPTION
So, basically, this breaks down the Kweb class internals in a couple of spots to increase Ktor compatibility (and also clean up a bit)

I've included an example that hopefully demonstrates the desired functionality. 

Unsure atm, if I have broken something completely unseen, do take a look!

Breaking change:
- For clients that were using Kweb in Ktor but using the buildpage param, this will be a breaking change (hence recommend a major version bump if we go that way. I can also make the change nonbreaking as well, and I think I probably should (this project has enough breaking changes anyway :P ). I'm just not sure what the defaults should be wrt accepting the buildpage for the Ktor feature on feature initialization (previous flow) vs defining in route (new flow, Ktor standard)