### PR TITLE
Issue 182 body element needs id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ data/
 
 .kotlintest
 phantomjsdriver.log
+/src/main/resources/logback.xml

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
 }
 
 group 'com.github.kwebio'
-version '0.8.5'
+version '0.8.7'
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/kweb/Element.kt
+++ b/src/main/kotlin/kweb/Element.kt
@@ -26,7 +26,7 @@ open class Element(
         val creator: ElementCreator<*>?,
         @Volatile open var jsExpression: String,
         val tag: String? = null,
-        @Volatile var id: String?
+        @Volatile var id: String
 ) :
         EventGenerator<Element> {
     constructor(element: Element) : this(element.browser, element.creator, jsExpression = element.jsExpression, tag = element.tag, id = element.id)
@@ -88,12 +88,11 @@ open class Element(
         if (value != null) {
             val htmlDoc = browser.htmlDocument.get()
             when {
-                htmlDoc != null && this.id != null -> {
+                htmlDoc != null -> {
                     htmlDoc.getElementById(this.id).attr(name, value.toString())
                 }
                 canSendInstruction() -> {
-                    browser.send(Server2ClientMessage.Instruction(type = Server2ClientMessage.Instruction.Type.SetAttribute, parameters = listOf(id, name, value)))
-                }
+                    browser.send(Server2ClientMessage.Instruction(type = Server2ClientMessage.Instruction.Type.SetAttribute, parameters = listOf(id, name, value)))                }
                 else -> {
                     execute("$jsExpression.setAttribute(\"${name.escapeEcma()}\", ${value.toJson()});")
                 }
@@ -130,7 +129,7 @@ open class Element(
         val htmlDoc = browser.htmlDocument.get()
         when {
             htmlDoc != null -> {
-                val thisEl = htmlDoc.getElementById(this.id!!)
+                val thisEl = htmlDoc.getElementById(this.id)
                 thisEl.html(html)
             }
             else -> {
@@ -216,9 +215,7 @@ open class Element(
         val htmlDoc = browser.htmlDocument.get()
         when {
             htmlDoc != null -> {
-                htmlDoc.getElementById(this.id).let { jsoupElement ->
-                    jsoupElement.children().remove()
-                }
+                htmlDoc.getElementById(this.id).children().remove()
             }
             else -> {
                 execute("""
@@ -257,7 +254,7 @@ open class Element(
         val jsoupDoc = browser.htmlDocument.get()
         when {
             jsoupDoc != null -> {
-                val element = jsoupDoc.getElementById(this.id ?: error("Can't find id $id in jsoupDoc"))
+                val element = jsoupDoc.getElementById(this.id)
                 element.text(value)
             }
             canSendInstruction() -> {
@@ -299,7 +296,7 @@ open class Element(
         val jsoupDoc = browser.htmlDocument.get()
         when {
             jsoupDoc != null -> {
-                val element = jsoupDoc.getElementById(this.id ?: error("Can't find id $id in jsoupDoc"))
+                val element = jsoupDoc.getElementById(this.id)
                 element.appendText(value)
             }
             canSendInstruction() -> {
@@ -359,7 +356,7 @@ open class Element(
 
     val flags = ConcurrentSkipListSet<String>()
 
-    fun canSendInstruction() = id != null && browser.kweb.isNotCatchingOutbound()
+    fun canSendInstruction() = browser.kweb.isNotCatchingOutbound()
 
     /**
      * See [here](https://docs.kweb.io/en/latest/dom.html#listening-for-events).

--- a/src/main/kotlin/kweb/html/BodyElement.kt
+++ b/src/main/kotlin/kweb/html/BodyElement.kt
@@ -9,4 +9,4 @@ import kweb.WebBrowser
  *
  * @sample document_sample
  */
-class BodyElement(webBrowser: WebBrowser, id: String? = null) : Element(webBrowser, null, "document.body", "body", id)
+class BodyElement(webBrowser: WebBrowser, id: String) : Element(webBrowser, null, "document.body", "body", id)

--- a/src/main/kotlin/kweb/html/Document.kt
+++ b/src/main/kotlin/kweb/html/Document.kt
@@ -17,7 +17,7 @@ import kweb.util.random
  * @sample document_sample
  */
 class Document(val receiver: WebBrowser) : EventGenerator<Document> {
-    fun getElementById(id: String) = Element(receiver, null, "document.getElementById(\"$id\")", id = id)
+    fun getElementById(id: String) = Element(receiver, null, """document.getElementById("$id")""", id = id)
 
     val cookie = CookieReceiver(receiver)
 

--- a/src/main/kotlin/kweb/html/Document.kt
+++ b/src/main/kotlin/kweb/html/Document.kt
@@ -21,7 +21,7 @@ class Document(val receiver: WebBrowser) : EventGenerator<Document> {
 
     val cookie = CookieReceiver(receiver)
 
-    val body = BodyElement(receiver)
+    val body = BodyElement(receiver, "K_body")
 
     fun body(new: (ElementCreator<BodyElement>.() -> Unit)? = null) : BodyElement {
         if (new != null) {
@@ -30,7 +30,7 @@ class Document(val receiver: WebBrowser) : EventGenerator<Document> {
         return body
     }
 
-    val head = HeadElement(receiver)
+    val head = HeadElement(receiver, "K_head")
 
     fun head(new: (ElementCreator<HeadElement>.() -> Unit)? = null) : HeadElement {
         if (new != null) {

--- a/src/main/kotlin/kweb/html/HeadElement.kt
+++ b/src/main/kotlin/kweb/html/HeadElement.kt
@@ -3,5 +3,5 @@ package kweb.html
 import kweb.Element
 import kweb.WebBrowser
 
-class HeadElement(webBrowser: WebBrowser, id: String? = null) : Element(webBrowser, null, "document.head", "head", id)
+class HeadElement(webBrowser: WebBrowser, id: String) : Element(webBrowser, null, "document.head", "head", id)
 open class TitleElement(parent: Element) : Element(parent)

--- a/src/main/kotlin/kweb/html/HtmlDocumentSupplier.kt
+++ b/src/main/kotlin/kweb/html/HtmlDocumentSupplier.kt
@@ -2,10 +2,12 @@ package kweb.html
 
 import io.ktor.routing.Routing
 import kweb.plugins.KwebPlugin
+import kweb.util.random
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.DocumentType
 import org.jsoup.nodes.Element
 import java.util.*
+import kotlin.math.abs
 
 internal object HtmlDocumentSupplier {
     val appliedPlugins: Set<KwebPlugin> get() = mutableAppliedPlugins
@@ -23,6 +25,7 @@ internal object HtmlDocumentSupplier {
             html.appendElement("head").let { head: Element ->
 
                 head.appendElement("meta")
+                    .attr("id", generateId())
                     .attr("name", "viewport")
                     .attr("content", "width=device-width, initial-scale=1.0")
             }
@@ -30,6 +33,7 @@ internal object HtmlDocumentSupplier {
             html.appendElement("body").let { body: Element ->
 
                 body.attr("onload", "buildPage()")
+                body.attr("id", generateId())
                 body.appendElement("noscript")
                     .html(
                         """
@@ -42,6 +46,10 @@ internal object HtmlDocumentSupplier {
             // The document will be modified here!
             applyPluginWithDependencies(plugin = plugin, appliedPlugins = mutableAppliedPlugins, document = docTemplate, routeHandler = routing)
         }
+    }
+
+    fun generateId() : String {
+        return "B" + abs(random.nextInt()).toString(36)
     }
 
     /**

--- a/src/main/kotlin/kweb/html/HtmlDocumentSupplier.kt
+++ b/src/main/kotlin/kweb/html/HtmlDocumentSupplier.kt
@@ -25,7 +25,7 @@ internal object HtmlDocumentSupplier {
             html.appendElement("head").let { head: Element ->
 
                 head.appendElement("meta")
-                    .attr("id", generateId())
+                    .attr("id", "K_head")
                     .attr("name", "viewport")
                     .attr("content", "width=device-width, initial-scale=1.0")
             }
@@ -33,7 +33,7 @@ internal object HtmlDocumentSupplier {
             html.appendElement("body").let { body: Element ->
 
                 body.attr("onload", "buildPage()")
-                body.attr("id", generateId())
+                body.attr("id", "K_body")
                 body.appendElement("noscript")
                     .html(
                         """
@@ -46,10 +46,6 @@ internal object HtmlDocumentSupplier {
             // The document will be modified here!
             applyPluginWithDependencies(plugin = plugin, appliedPlugins = mutableAppliedPlugins, document = docTemplate, routeHandler = routing)
         }
-    }
-
-    fun generateId() : String {
-        return "B" + abs(random.nextInt()).toString(36)
     }
 
     /**


### PR DESCRIPTION
I ran into an issue here, https://github.com/Derek52/kweb-core/blob/ee2f1c7cb09225eb3f28651192d264bc1a50c9c1/src/main/kotlin/kweb/html/Document.kt#L19-L40

Here, Document.kt is creating a Body and a Head element. Now that id's are non-nullable they need id's passed to them. But, I assign an id to these elements in HtmlDocumentSupplier like we talked about. I would think we need the same id passed to these elements in both source files, and I'm not seeing a way to do that. I imagine this might have factored into the decision to not include the id's in the first place.