### PR TITLE
#193 Create KwebConfiguration class, use for client,page timeouts

### DIFF
--- a/src/main/kotlin/kweb/Kweb.kt
+++ b/src/main/kotlin/kweb/Kweb.kt
@@ -2,8 +2,6 @@ package kweb
 
 import com.github.salomonbrys.kotson.fromJson
 import com.google.common.cache.CacheBuilder
-import com.google.common.cache.CacheLoader
-import com.google.common.cache.LoadingCache
 import io.ktor.application.*
 import io.ktor.features.*
 import io.ktor.http.*
@@ -19,7 +17,6 @@ import io.ktor.websocket.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.time.delay
 import kweb.client.*
 import kweb.client.ClientConnection.Caching
 import kweb.config.KwebConfiguration
@@ -34,10 +31,7 @@ import java.io.Closeable
 import java.time.Duration
 import java.time.Instant
 import java.util.*
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.ArrayList
-import kotlin.collections.component1
-import kotlin.collections.component2
 import kotlin.math.abs
 
 private val logger = KotlinLogging.logger {}

--- a/src/main/kotlin/kweb/Kweb.kt
+++ b/src/main/kotlin/kweb/Kweb.kt
@@ -68,7 +68,7 @@ class Kweb private constructor(
             logger.warn("Debug mode enabled, if in production use KWeb(debug = false)")
         }
 
-
+        KwebConfiguration.validate()
 
         server = createServer(port, httpsConfig, buildPage)
 
@@ -98,6 +98,7 @@ class Kweb private constructor(
      * @see kweb.demos.feature.kwebFeature for an example
      */
     companion object Feature : ApplicationFeature<Application, Feature.Configuration, Kweb> {
+        // Note that this is not KwebConfiguration, which is a different thing
         class Configuration {
             var debug: Boolean = true
             var plugins: List<KwebPlugin> = Collections.emptyList()
@@ -109,6 +110,7 @@ class Kweb private constructor(
 
         override fun install(pipeline: Application, configure: Configuration.() -> Unit): Kweb {
             val configuration = Configuration().apply(configure)
+            KwebConfiguration.validate()
             val feature = Kweb(configuration.debug, configuration.plugins)
 
             configuration.buildPage?.let {

--- a/src/main/kotlin/kweb/KwebConfiguration.kt
+++ b/src/main/kotlin/kweb/KwebConfiguration.kt
@@ -1,0 +1,55 @@
+package kweb
+
+import mu.KotlinLogging
+import java.time.Duration
+
+/**
+ * A central configuration class for Kweb parameterization
+ *
+ * Please note this is not [Kweb.Feature.Configuration], which is a Ktor specific config block
+ *
+ */
+object KwebConfiguration {
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * See [Duration.parse] for valid formats, e.g PT5S, or PT48H
+     */
+    val BUILDPAGE_TIMEOUT: Duration =
+        Accessor.getProperty("kweb.buildpage.timeout")?.let { Duration.parse(it) }
+            ?: Duration.ofSeconds(5)
+
+    /**
+     * Don't put this too low, you may end up cleaning semi-active clients
+     */
+    val CLIENT_STATE_TIMEOUT: Duration =
+        Accessor.getProperty("kweb.client.state.timeout")?.let { Duration.parse(it) }
+            ?: Duration.ofHours(48)
+
+    /**
+     * Values are initialized eagerly, but objects are not, so be sure to "touch" this class
+     * on initialization for failing fast.
+     *
+     * We can also add some smarter validation here later if needed
+     */
+    fun validate() {
+        logger.debug("Configuration has been initialized successfully")
+    }
+
+    private object Accessor {
+        private val env = System.getenv()
+
+        /**
+         * Gets the value of the given property by searching runtime properties,
+         * then env, then uppercase ENV. Each case is only examined if the previous one failed.
+         *
+         * So, if you provide a [key] value such as "kweb.test", the following will happen
+         * - First "kweb.test" will be looked up as a run argument
+         * - Then "kweb.test" is looked up in env variables (the JVM is kinda bad at lowercase ENV vars in my experience)
+         * - Then "KWEB_TEST" is looked up in env variables
+         * - Then null is returned
+         */
+        fun getProperty(key: String): String? =
+            System.getProperty(key, env[key] ?: env[key.toUpperCase().replace('.', '_')])
+    }
+}

--- a/src/main/kotlin/kweb/KwebConfiguration.kt
+++ b/src/main/kotlin/kweb/KwebConfiguration.kt
@@ -33,7 +33,7 @@ object KwebConfiguration {
      * We can also add some smarter validation here later if needed
      */
     fun validate() {
-        logger.debug("Configuration has been initialized successfully")
+        logger.debug { "Configuration has been initialized successfully" }
     }
 
     private object Accessor {

--- a/src/main/kotlin/kweb/config/KwebConfiguration.kt
+++ b/src/main/kotlin/kweb/config/KwebConfiguration.kt
@@ -1,30 +1,34 @@
-package kweb
+package kweb.config
 
 import mu.KotlinLogging
 import java.time.Duration
 
 /**
- * A central configuration class for Kweb parameterization
+ * A configuration class for Kweb parameterization. Extend this if you have custom needs
+ * on how to inject configuration values, otherwise [KwebDefaultConfiguration] is probably
+ * good enough for your use case
  *
  * Please note this is not [Kweb.Feature.Configuration], which is a Ktor specific config block
- *
  */
-object KwebConfiguration {
+abstract class KwebConfiguration {
     private val logger = KotlinLogging.logger {}
 
     /**
+     * If [Kweb.debug] is enabled, then pages that take longer than [buildpageTimeout]
+     * to load will display a warning message
+     *
      * See [Duration.parse] for valid formats, e.g PT5S, or PT48H
      */
-    val BUILDPAGE_TIMEOUT: Duration =
-        Accessor.getProperty("kweb.buildpage.timeout")?.let { Duration.parse(it) }
-            ?: Duration.ofSeconds(5)
+    abstract val buildpageTimeout: Duration
 
     /**
-     * Don't put this too low, you may end up cleaning semi-active clients
+     * Clients that last connected more than [clientStateTimeout] will be cleaned
+     * up every minute.
+     *
+     * Don't put this too low, you may end up cleaning semi-active clients, e.g someone
+     * who left a page open for a long duration without actions, such as a monitoring page.
      */
-    val CLIENT_STATE_TIMEOUT: Duration =
-        Accessor.getProperty("kweb.client.state.timeout")?.let { Duration.parse(it) }
-            ?: Duration.ofHours(48)
+    abstract val clientStateTimeout: Duration
 
     /**
      * Values are initialized eagerly, but objects are not, so be sure to "touch" this class
@@ -36,7 +40,7 @@ object KwebConfiguration {
         logger.debug { "Configuration has been initialized successfully" }
     }
 
-    private object Accessor {
+    protected object Accessor {
         private val env = System.getenv()
 
         /**

--- a/src/main/kotlin/kweb/config/KwebDefaultConfiguration.kt
+++ b/src/main/kotlin/kweb/config/KwebDefaultConfiguration.kt
@@ -1,0 +1,17 @@
+package kweb.config
+
+import java.time.Duration
+
+/**
+ * A default [KwebConfiguration] using runtime arguments
+ */
+internal object KwebDefaultConfiguration : KwebConfiguration() {
+
+    override val buildpageTimeout: Duration =
+            Accessor.getProperty("kweb.buildpage.timeout")?.let { Duration.parse(it) }
+                    ?: Duration.ofSeconds(5)
+
+    override val clientStateTimeout: Duration =
+            Accessor.getProperty("kweb.client.state.timeout")?.let { Duration.parse(it) }
+                    ?: Duration.ofHours(48)
+}


### PR DESCRIPTION
# Summary
This PR introduces configuration options for Kweb.

## Motivation
While Kweb does make use of a few variables here and there, they are mostly declared locally and hardcoded to static values. There exists neither a centralized repository for these values, nor a way for users to override them based on their specific needs. Inspired by the standard approach in JVM projects I've implemented exactly that.

I opted not to use one of the existing libraries for reading configs. I felt that the current use case is small enough and that Kweb does a pretty good job being polite with people's classpath already, which I don't want to inhibit. Additionally, I like the fact that Kweb is super simple on a lot of its core functionality, and I feel this fits.

Docs should hopefully be plentiful enough already in these classes (they actually outline the code lines), but I'll go over the code functionality and choices quickly here:
- `KwebConfiguration` class. Kweb prefix to avoid name collisions with any of the other `Configuration` classes on the classpath, including our own `Kweb.Feature.Configuration`
- Property accessor that fetches from runtime arguments, then env variables and can automatically uppercase
- Kweb prefix on the property keys, because we're good citizens with people's conf options
- Slightly adapted the var names to create a hierarchical progression (`kweb.client.state.timeout`), enforced some standard suffixes
- Validate function so you can fail fast(er)

## About text files
Files are not currently supported. Not Ktor HOCONs, not Spring Boot HOCONs, not resource bundles. This is a conscious choice, as I didn't want to enforce my beliefs on what the text standard should be, but also because there are multiple traps of complexity (reading resource bundles from the modulepath, brrrrr) that I didn't intend to tackle yet.

## Extensions
Text files are obviously the next major step, but there's some open questions about them - what format should they have, which standard should they follow (I strongly recommend against defining a new one). On top of all of this we need to keep in mind the Ktor feature support and what kind of configuration API we provide to the Ktor users (not talking about `Kweb.Feature.Configuration`, but more about defining the config options in Ktor HOCONs, which may actually collide with that Configuration).

I didn't put a lot of effort in, but it feels like there's some use case in letting users actually take advantage of `KwebConfiguration` class, since it's on their classpath already, so maybe it can switch to a class and `KwebConfiguration` can be a companion object.