### PR TITLE
fix double escaped class strings

### DIFF
--- a/src/main/kotlin/kweb/Element.kt
+++ b/src/main/kotlin/kweb/Element.kt
@@ -165,7 +165,7 @@ open class Element(
     fun classes(vararg value: String) = setClasses(*value)
 
     fun setClasses(vararg value: String): Element {
-        setAttributeRaw("class", value.joinToString(separator = " ").toJson())
+        setAttributeRaw("class", value.joinToString(separator = " "))
         return this
     }
 


### PR DESCRIPTION
fixes double escaped class string see: https://github.com/kwebio/kweb-core/issues/178
No idea if there was a good reason for having the `toJson()` there.  Please enlighten me  : )