### PR TITLE
Allow exporting stats for client state cache

### DIFF
--- a/src/main/kotlin/kweb/Kweb.kt
+++ b/src/main/kotlin/kweb/Kweb.kt
@@ -135,7 +135,7 @@ class Kweb private constructor(
 
     val clientState: Cache<String, RemoteClientState> = CacheBuilder.newBuilder()
         .expireAfterAccess(kwebConfig.clientStateTimeout)
-        .apply { if (kwebConfig.clientStateStats) recordStats() }
+        .apply { if (kwebConfig.clientStateStatsEnabled) recordStats() }
         .build()
 
     //: ConcurrentHashMap<String, RemoteClientState> = ConcurrentHashMap()

--- a/src/main/kotlin/kweb/Kweb.kt
+++ b/src/main/kotlin/kweb/Kweb.kt
@@ -36,9 +36,6 @@ import java.time.Instant
 import java.util.*
 import kotlin.math.abs
 
-private val MAX_PAGE_BUILD_TIME: Duration = Duration.ofSeconds(5)
-private val CLIENT_STATE_TIMEOUT: Duration = Duration.ofHours(48)
-
 private val logger = KotlinLogging.logger {}
 
 class Kweb private constructor(

--- a/src/main/kotlin/kweb/Kweb.kt
+++ b/src/main/kotlin/kweb/Kweb.kt
@@ -1,5 +1,6 @@
 package kweb
 
+import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
 import io.ktor.application.*
 import io.ktor.features.*
@@ -132,9 +133,10 @@ class Kweb private constructor(
         }
     }
 
-    private val clientState = CacheBuilder.newBuilder()
+    val clientState: Cache<String, RemoteClientState> = CacheBuilder.newBuilder()
         .expireAfterAccess(kwebConfig.clientStateTimeout)
-        .build<String, RemoteClientState>()
+        .apply { if (kwebConfig.clientStateStats) recordStats() }
+        .build()
 
     //: ConcurrentHashMap<String, RemoteClientState> = ConcurrentHashMap()
 

--- a/src/main/kotlin/kweb/config/KwebConfiguration.kt
+++ b/src/main/kotlin/kweb/config/KwebConfiguration.kt
@@ -6,6 +6,7 @@ import io.ktor.response.*
 import kweb.Kweb
 import mu.KotlinLogging
 import java.time.Duration
+import java.util.*
 
 /**
  * A configuration class for Kweb parameterization. Extend this if you have custom needs
@@ -24,6 +25,12 @@ abstract class KwebConfiguration {
      * See [Duration.parse] for valid formats, e.g PT5S, or PT48H
      */
     abstract val buildpageTimeout: Duration
+
+    /**
+     * Enable stats for the client state cache. Small performance penalty per operation,
+     * large gains in observability. Consider this in production.
+     */
+    abstract val clientStateStats: Boolean
 
     /**
      * Clients that last connected more than [clientStateTimeout] will be cleaned
@@ -79,6 +86,6 @@ abstract class KwebConfiguration {
          * - Then null is returned
          */
         fun getProperty(key: String): String? =
-            System.getProperty(key, env[key] ?: env[key.toUpperCase().replace('.', '_')])
+            System.getProperty(key, env[key] ?: env[key.uppercase(Locale.getDefault()).replace('.', '_')])
     }
 }

--- a/src/main/kotlin/kweb/config/KwebConfiguration.kt
+++ b/src/main/kotlin/kweb/config/KwebConfiguration.kt
@@ -30,7 +30,7 @@ abstract class KwebConfiguration {
      * Enable stats for the client state cache. Small performance penalty per operation,
      * large gains in observability. Consider this in production.
      */
-    abstract val clientStateStats: Boolean
+    abstract val clientStateStatsEnabled: Boolean
 
     /**
      * Clients that last connected more than [clientStateTimeout] will be cleaned

--- a/src/main/kotlin/kweb/config/KwebDefaultConfiguration.kt
+++ b/src/main/kotlin/kweb/config/KwebDefaultConfiguration.kt
@@ -11,8 +11,8 @@ open class KwebDefaultConfiguration : KwebConfiguration() {
             Accessor.getProperty("kweb.buildpage.timeout")?.let { Duration.parse(it) }
                     ?: Duration.ofSeconds(5)
 
-    override val clientStateStats: Boolean =
-        Accessor.getProperty("kweb.client.state.stats")?.toBooleanStrictOrNull()
+    override val clientStateStatsEnabled: Boolean =
+        Accessor.getProperty("kweb.client.state.stats.enabled")?.toBooleanStrictOrNull()
             ?: false
 
     override val clientStateTimeout: Duration =

--- a/src/main/kotlin/kweb/config/KwebDefaultConfiguration.kt
+++ b/src/main/kotlin/kweb/config/KwebDefaultConfiguration.kt
@@ -11,6 +11,10 @@ open class KwebDefaultConfiguration : KwebConfiguration() {
             Accessor.getProperty("kweb.buildpage.timeout")?.let { Duration.parse(it) }
                     ?: Duration.ofSeconds(5)
 
+    override val clientStateStats: Boolean =
+        Accessor.getProperty("kweb.client.state.stats")?.toBooleanStrictOrNull()
+            ?: false
+
     override val clientStateTimeout: Duration =
             Accessor.getProperty("kweb.client.state.timeout")?.let { Duration.parse(it) }
                     ?: Duration.ofMinutes(5)


### PR DESCRIPTION
Howdy folks,

## Summary

This PR introduces the capability to optionally get stats for the Guava Cache that sits at the heart of Kweb, `clientState`, as well as a switch to control the stats collection (off by default due to the performance cost). Important to note here, is that to actually take advantage of this functionality, clientState needed to become public. I am interested in hearing if there was a strong reason to keep it private, so that I can perhaps rearchitect the solution, though that'll be hard.

## Context

We've recently started digging deeper into clientState again due to some performance issues with long-lived clients indicating (again) some sort of memory-leak-like pattern. I may follow up with more PRs in this space if I detect areas for improvement.

## Technical decisions

Not a lot, tbh. I opted to use the `recordStats` functionality in Guava, rather than write my own wrapper for it, as it is well supported by the [Prometheus Java client](https://prometheus.github.io/client_java/io/prometheus/client/guava/cache/CacheMetricsCollector.html). 

## Usage example

Here's a usage example that's close to my currently working one (slightly simplified). Note that I use the Ktor plugin declaration style.

```
private val guavaCacheMetrics : CacheMetricsCollector by lazy { CacheMetricsCollector().register(registry) }
...

    install(Kweb) {
        plugins = listOf(ResourcesPlugin)
        debug = false
    }.apply {
        guavaCacheMetrics.addCache("clientState", clientState)
    }
```