### PR TITLE
Remove eager collection initializations from ElementCreator

### DIFF
--- a/src/main/kotlin/kweb/Element.kt
+++ b/src/main/kotlin/kweb/Element.kt
@@ -38,7 +38,7 @@ open class Element(
      * foundation upon which most other DOM modification functions in this class
      * are based. `{}`s in the js String will be replaced by the `args` values
      * in the order in which they're present in the js String.
-     * 
+     *
      * Note that this will cache functions in the browser to avoid unnecessary
      * re-interpretation, making this fairly efficient.
      *
@@ -558,7 +558,7 @@ open class Element(
      */
     val style get() = StyleReceiver(this)
 
-    val flags = ConcurrentSkipListSet<String>()
+    val flags : ConcurrentSkipListSet<String> by lazy { ConcurrentSkipListSet() }
 
     /**
      * See [here](https://docs.kweb.io/en/latest/dom.html#listening-for-events).


### PR DESCRIPTION
Hello again,

## Summary

This PR vastly reduces some the memory overhead (we're seeing ~20%) for complex Kweb pages by removing the eager initialization for collections within `Element` and `ElementCreator`. There is (or should be) no change in behavior as these collections will be initialized lazily when needed.

## Context

Same performance deep-dive as #229 led us to find that each element creates multiple collections (often completely empty) eagerly.