### PR TITLE
Element memory improvements

### DIFF
--- a/src/main/kotlin/kweb/ElementCreator.kt
+++ b/src/main/kotlin/kweb/ElementCreator.kt
@@ -31,6 +31,7 @@ open class ElementCreator<out PARENT_TYPE : Element>(
 
     companion object : KLogging()
 
+    @Volatile
     private var cleanupListeners: MutableCollection<Cleaner>? = null
 
     @Volatile

--- a/src/main/kotlin/kweb/ElementCreator.kt
+++ b/src/main/kotlin/kweb/ElementCreator.kt
@@ -11,6 +11,7 @@ import kweb.util.json
 import mu.KLogging
 import java.util.*
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.reflect.KClass
 
 typealias Cleaner = () -> Unit
@@ -37,11 +38,8 @@ open class ElementCreator<out PARENT_TYPE : Element>(
     @Volatile
     private var isCleanedUp = false
 
-    val elementsCreatedCount: Int get() = elementsCreated.size
-
-    internal val elementsCreated: ConcurrentLinkedQueue<Element> by lazy {
-        ConcurrentLinkedQueue()
-    }
+    val elementsCreatedCount: Int get() = elementsCreatedCountAtomic.get()
+    private val elementsCreatedCountAtomic = AtomicInteger(0)
 
     val browser: WebBrowser get() = parent.browser
 
@@ -147,7 +145,7 @@ open class ElementCreator<out PARENT_TYPE : Element>(
             }
         }
         val newElement = Element(parent.browser, this, tag = tag, id = id)
-        elementsCreated += newElement
+        elementsCreatedCountAtomic.incrementAndGet()
         for (plugin in parent.browser.kweb.plugins) {
             plugin.elementCreationHook(newElement)
         }

--- a/src/main/kotlin/kweb/state/render.kt
+++ b/src/main/kotlin/kweb/state/render.kt
@@ -187,7 +187,7 @@ private fun <ITEM : Any, EL : Element> ElementCreator<EL>.createItem(
          */
         error(
             """
-            Only one element may be created per item but ${itemElementCreator.elementsCreated} were created for
+            Only one element may be created per item but ${itemElementCreator.elementsCreatedCount} were created for
             item key ${keyValue.key}.  Note that this element may have as many children as you like, so you may just need
             to wrap the elements in a <DIV> or other element type.
 """.trimIndent()


### PR DESCRIPTION
Hola!

## Summary

This PR fixes a minor concurrency trap that @sanity spotted, and removes one of the major offenders of Kweb's memory usage: The `ConcurrentLinkedQueue` that comes with every element creator.

## Context

If you look at the heap of a Kweb app, one of the things that pops out is that there is a 1:1 between `Element`s and `ConcurrentLinkedQueue`s. This is actually because each `ElementCreator` keeps such a queue for all elements created with it, but in practice it only ever has a single node. In addition, the variable is internal which allows us to investigate its uses... and it's unused by anything besides a count. It is prudent to remove it and spare ourselves the weight that this data structure brings (the queue itself, the single node in it, and the 2 locks)

## Decisions

Because `elementsCreatedCount` is public on `ElementCreator` and consumers may be using it downstream, I opted to keep its API the exact same (int, that's basically a getter). The alternative option is to make it an AtomicInteger and avoid the "shadow" private variable that accompanies it. I'm okay with both, so I chose less breakage, but I'm open to hearing the alternative.