### PR TITLE
Minor bug fixes, feature enhancements and changes for better observability in production

### DIFF
--- a/src/main/kotlin/kweb/BootstrapJs.kt
+++ b/src/main/kotlin/kweb/BootstrapJs.kt
@@ -7,20 +7,22 @@ object BootstrapJs {
     private const val clientIdToken = "--CLIENT-ID-PLACEHOLDER--"
     private const val buildPageToken = "<!-- BUILD PAGE PAYLOAD PLACEHOLDER -->"
     private const val functionCacheToken = "<!-- FUNCTION CACHE PLACEHOLDER -->"
+    private const val offlineBannerMessage = "-- BANNER MESSAGE PLACEHOLDER --"
+    private const val offlineBannerStyle = "-- BANNER STYLE PLACEHOLDER --"
 
     private val template: Template by lazy {
         Kweb::class.java.getResourceAsStream("kweb_bootstrap.js").use { resourceStream ->
             val jsAsString = IOUtils.toString(resourceStream, "UTF-8")
             // By storing the Template we only need to locate the tokens once
-            Template(jsAsString, clientIdToken, buildPageToken, functionCacheToken)
+            Template(jsAsString, clientIdToken, buildPageToken, functionCacheToken, offlineBannerMessage, offlineBannerStyle)
         }
     }
 
     /**
      * Efficiently inject required data into kweb_bootstrap.js
      */
-    fun hydrate(clientId: String, pageBuildInstructions: String, functionCache: String): String {
-        return template.apply(clientId, pageBuildInstructions, functionCache)
+    fun hydrate(clientId: String, pageBuildInstructions: String, functionCache: String, offlineBannerMessageStr: String, offlineBannerStyleDef : String): String {
+        return template.apply(clientId, pageBuildInstructions, functionCache, offlineBannerMessageStr, offlineBannerStyleDef)
     }
 }
 

--- a/src/main/kotlin/kweb/WebBrowser.kt
+++ b/src/main/kotlin/kweb/WebBrowser.kt
@@ -32,7 +32,7 @@ private val logger = KotlinLogging.logger {}
  * expressions and retrieve the result.
  */
 
-class WebBrowser(private val sessionId: String, val httpRequestInfo: HttpRequestInfo, val kweb: Kweb) {
+class WebBrowser(val sessionId: String, val httpRequestInfo: HttpRequestInfo, val kweb: Kweb) {
 
     private val idCounter = AtomicInteger(0)
 

--- a/src/main/kotlin/kweb/config/KwebConfiguration.kt
+++ b/src/main/kotlin/kweb/config/KwebConfiguration.kt
@@ -72,6 +72,17 @@ abstract class KwebConfiguration {
         call.respondText("favicons not currently supported by kweb", status = HttpStatusCode.NotFound)
     }
 
+    /**
+     * Message that is shown to a disconnected client.
+     *
+     */
+    open val clientOfflineBannerTextTemplate: String = "Connection to server lost, attempting to reconnect in \${reconnectTimeout/1000} seconds"
+
+    /**
+     * Style of the message that is shown to a disconnected client
+     */
+    open val clientOfflineBannerStyle: String = "background-color: yellow; text-align: center;"
+
     protected object Accessor {
         private val env = System.getenv()
 

--- a/src/main/resources/kweb/kweb_bootstrap.js
+++ b/src/main/resources/kweb/kweb_bootstrap.js
@@ -9,6 +9,7 @@ let preWSMsgQueue = [];
 let socket;
 let bannerId = "CkU6vMWzW0Hbp"  // Random id to avoid conflicts
 let reconnectTimeout = 1000
+let reconnectCount = 0
 
 <!-- FUNCTION CACHE PLACEHOLDER -->
 
@@ -125,6 +126,10 @@ function connectWs() {
                 explanation = "without a reason specified";
             }
 
+            if(evt.code == 1007){ //Server did restart or load balancer shifted session to other backend
+                location.reload(true);
+            }
+
             console.error("WebSocket was closed", explanation, evt);
             websocketEstablished = false;
             reconnectLoopWs();
@@ -138,6 +143,7 @@ function connectWs() {
 
 function reconnectLoopWs() {
     reconnectTimeout *= 2
+
     createBannerIfNotExists();
 
     setTimeout(function() {
@@ -155,14 +161,28 @@ function reconnectLoopWs() {
 
 function createBannerIfNotExists() {
     var banner = document.getElementById(bannerId);
+
     if (typeof(banner) == 'undefined' || banner == null) {
         banner = document.createElement("h1");
         banner.id = bannerId
-        banner.innerHTML = `Connection to server lost, attempting to reconnect in ${reconnectTimeout/1000} seconds`;
-        banner.style = "background-color: yellow; text-align: center;";
+        banner.style = "-- BANNER STYLE PLACEHOLDER --";
+
+        msg = document.createElement("span")
+        msg.innerHTML = `-- BANNER MESSAGE PLACEHOLDER --`;
+
+        banner.append(msg)
+
+        reloadNow = document.createElement("button")
+        reloadNow.onclick = function (){
+            connectWs()
+        }
+        reloadNow.innerHTML = `Retry`
+
+        banner.append(reloadNow)
+
         document.body.insertBefore(banner,document.body.childNodes[0]);
     } else {
-        banner.innerHTML = `Connection to server lost, attempting to reconnect in ${reconnectTimeout/1000} seconds`;
+        banner.children[0].innerHTML = `-- BANNER MESSAGE PLACEHOLDER --`;
     }
 }
 


### PR DESCRIPTION
1. Fixed #235. The Banner is now configurable from the config.
2. Fixed a bug that kweb did not properly reconnect when the kweb backend was restarted and thus the session was no longer known.
3. Added a manual reload button to the banner as it may be lengthy to wait for a reload and the state is lost if the user presses the reload button of the browser.
4. Changed the visibility of the  sessionId variable in the browser object. This variable is no longer private. This is needed to cleanup sessions that are terminated on behalf of the backend (e.g. when an explicit navigation event is triggered). 
5. Added a prefix to the kweb session id to allow tracking how many sessions an user has. This is important for me as some users create an excessive amount of sessions and i need some application layer code to cleanup. Especially as i have some kvar-listeners that prevent memory from beeing freed by the garbage collector unless the session is terminated. The prefix is derived from a client side cookie so that all browser tabs within the same browser get the same prefix.