### PR TITLE
initial buildSrc setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,74 +1,74 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.7.20"
-    id 'maven-publish'
-    id 'org.jetbrains.dokka' version '1.7.10'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
-    id "com.github.ben-manes.versions" version "0.42.0"
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.7.20'
+    id("org.jetbrains.kotlin.jvm") version "1.7.20"
+    id("maven-publish")
+    id("org.jetbrains.dokka") version "1.7.10"
+    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.ben-manes.versions") version "0.42.0"
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.7.20"
 }
 
 allprojects {
     repositories {
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        maven { url("https://jitpack.io") }
     }
 }
 
-tasks.named('test') {
+tasks.named("test") {
     useJUnitPlatform()
-    systemProperty('sel.jup.default.browser', System.getProperty('sel.jup.default.browser'))
+    systemProperty("sel.jup.default.browser", System.getProperty("sel.jup.default.browser"))
 }
 
 dependencies {
-    api 'org.jsoup:jsoup:1.15.3'
-    implementation 'org.apache.commons:commons-text:1.10.0'
-    implementation 'com.google.guava:guava:31.1-jre'
+    api("org.jsoup:jsoup:1.15.3")
+    implementation("org.apache.commons:commons-text:1.10.0")
+    implementation("com.google.guava:guava:31.1-jre")
 
     //////////////////////////////
     // Kotlin library dependencies
     //////////////////////////////
 
-    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
-    api 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4'
-    api 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0'
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4")
+    api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0")
 
     ////////////////////
     // Ktor dependencies
     ////////////////////
-    api "io.ktor:ktor-server-jetty:2.1.2"
-    api "io.ktor:ktor-server-websockets:2.1.2"
-    api "io.ktor:ktor-server-default-headers:2.1.2"
-    api "io.ktor:ktor-server-compression:2.1.2"
-    api "io.ktor:ktor-server-caching-headers:2.1.2"
-    api "io.ktor:ktor-network-tls-certificates:2.1.2"
+    api("io.ktor:ktor-server-jetty:2.1.2")
+    api("io.ktor:ktor-server-websockets:2.1.2")
+    api("io.ktor:ktor-server-default-headers:2.1.2")
+    api("io.ktor:ktor-server-compression:2.1.2")
+    api("io.ktor:ktor-server-caching-headers:2.1.2")
+    api("io.ktor:ktor-network-tls-certificates:2.1.2")
 
-    api 'io.mola.galimatias:galimatias:0.2.1'
+    api("io.mola.galimatias:galimatias:0.2.1")
 
-    implementation 'io.github.microutils:kotlin-logging:3.0.0'
+    implementation("io.github.microutils:kotlin-logging:3.0.0")
 
     ///////////////////////////
     // Dependencies for testing
     ///////////////////////////
     // Pinned to 5.4.2 for now since there are issues with test discovery in 5.5.0
     // See: https://github.com/kotest/kotest/issues/3223
-    testApi(platform('io.kotest:kotest-bom:5.5.0'))
-    testApi(platform('org.junit:junit-bom:5.9.1'))
+    testApi(platform("io.kotest:kotest-bom:5.5.0"))
+    testApi(platform("org.junit:junit-bom:5.9.1"))
 
-    testImplementation 'io.kotest:kotest-runner-junit5'
-    testImplementation 'io.kotest:kotest-assertions-core'
+    testImplementation("io.kotest:kotest-runner-junit5")
+    testImplementation("io.kotest:kotest-assertions-core")
 
-    testImplementation 'ch.qos.logback:logback-classic:1.4.3'
+    testImplementation("ch.qos.logback:logback-classic:1.4.3")
 
-    testImplementation 'org.seleniumhq.selenium:selenium-opera-driver:4.4.0'
-    testImplementation 'org.seleniumhq.selenium:selenium-chrome-driver:4.5.0'
-    testImplementation 'org.seleniumhq.selenium:selenium-java:4.5.0'
-    testImplementation 'io.github.bonigarcia:selenium-jupiter:4.3.1'
+    testImplementation("org.seleniumhq.selenium:selenium-opera-driver:4.4.0")
+    testImplementation("org.seleniumhq.selenium:selenium-chrome-driver:4.5.0")
+    testImplementation("org.seleniumhq.selenium:selenium-java:4.5.0")
+    testImplementation("io.github.bonigarcia:selenium-jupiter:4.3.1")
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
-tasks.named('dokkaHtml') {
+tasks.named("dokkaHtml") {
     dokkaSourceSets {
         configureEach {
             samples.from(files("src/main/kotlin/samples.kt"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,11 +10,11 @@ plugins {
 allprojects {
     repositories {
         mavenCentral()
-        maven { url("https://jitpack.io") }
+        maven("https://jitpack.io")
     }
 }
 
-tasks.named("test") {
+tasks.test {
     useJUnitPlatform()
     systemProperty("sel.jup.default.browser", System.getProperty("sel.jup.default.browser"))
 }
@@ -65,13 +65,13 @@ dependencies {
     testImplementation("io.github.bonigarcia:selenium-jupiter:4.3.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+    testRuntimeOnly ("org.junit.jupiter:junit-jupiter-engine")
 }
 
-tasks.named("dokkaHtml") {
+tasks.dokkaHtml {
     dokkaSourceSets {
         configureEach {
-            samples.from(files("src/main/kotlin/samples.kt"))
+            samples.from(layout.projectDirectory.dir("src/main/kotlin/samples.kt"))
         }
     }
 }
@@ -79,7 +79,7 @@ tasks.named("dokkaHtml") {
 afterEvaluate {
     publishing {
         publications {
-            create(MavenPublication) {
+            create<MavenPublication>("mavenJava") {
                 groupId = "com.github.kwebio"
                 artifactId = "kweb-core"
                 version = version

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,13 +7,6 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization") version "1.7.20"
 }
 
-allprojects {
-    repositories {
-        mavenCentral()
-        maven("https://jitpack.io")
-    }
-}
-
 tasks.test {
     useJUnitPlatform()
     systemProperty("sel.jup.default.browser", System.getProperty("sel.jup.default.browser"))

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,28 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    `kotlin-dsl`
+    kotlin("jvm") version embeddedKotlinVersion
+}
+
+dependencies {
+    implementation(platform(kotlin("bom")))
+}
+
+val gradleJvmTarget = 17
+
+kotlin {
+    jvmToolchain {
+        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(gradleJvmTarget))
+    }
+}
+
+kotlinDslPluginOptions {
+    jvmTarget.set("$gradleJvmTarget")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "$gradleJvmTarget"
+    }
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(platform(kotlin("bom")))
 }
 
-val gradleJvmTarget = 17
+val gradleJvmTarget = 11
 
 kotlin {
     jvmToolchain {

--- a/buildSrc/repositories.settings.gradle.kts
+++ b/buildSrc/repositories.settings.gradle.kts
@@ -1,0 +1,23 @@
+// Centralized Repository configuration, that will be shared between both buildSrc and the root project
+
+@Suppress("UnstableApiUsage") // Central declaration of repositories is an incubating feature
+dependencyResolutionManagement {
+
+    repositories {
+        mavenCentral()
+        jitpack()
+        gradlePluginPortal()
+    }
+
+    pluginManagement {
+        repositories {
+            gradlePluginPortal()
+            mavenCentral()
+            jitpack()
+        }
+    }
+}
+
+fun RepositoryHandler.jitpack() {
+    maven("https://jitpack.io")
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "buildSrc"
+
+apply(from = "./repositories.settings.gradle.kts")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,0 @@
-rootProject.name = 'kweb-core'
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,3 @@
 rootProject.name = "kweb-core"
+
+apply(from = "./buildSrc/repositories.settings.gradle.kts")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "kweb-core"


### PR DESCRIPTION
Set up a skeleton buildSrc project. This will be used for creating convention plugins, and making the Gradle build config more modular. 

https://docs.gradle.org/current/userguide/organizing_gradle_projects.html#sec:build_sources

This PR includes changes from https://github.com/kwebio/kweb-core/pull/318

I've also done the following: 

* set up [centralised repositories declaration](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:centralized-repository-declaration), so the repositories can be set in one place
* I've gone even further and defined the repositories in a [script plugin](https://docs.gradle.org/current/userguide/plugins.html#sec:script_plugins). This is not usually recommended, but it's actually quite difficult to set up a plugin `settings.gradle.kts` the 'correct' way. The `repositories.settings.gradle.kts` script plugin is much easier! 