### PR TITLE
Gradle version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,66 +1,69 @@
 plugins {
     buildsrc.conventions.`kotlin-jvm`
     buildsrc.conventions.`maven-publish`
-    id("org.jetbrains.dokka") version "1.7.10"
-    id("com.github.johnrengelman.shadow") version "7.1.2"
-    id("com.github.ben-manes.versions") version "0.42.0"
+    id("org.jetbrains.dokka")
+    id("com.github.johnrengelman.shadow")
+    id("com.github.ben-manes.versions")
     kotlin("plugin.serialization")
 }
 
 group = "com.github.kwebio"
 version = "0.0.1-SNAPSHOT"
 
-tasks.test {
-    systemProperty("sel.jup.default.browser", System.getProperty("sel.jup.default.browser"))
-}
-
 dependencies {
-    api("org.jsoup:jsoup:1.15.3")
-    implementation("org.apache.commons:commons-text:1.10.0")
-    implementation("com.google.guava:guava:31.1-jre")
+    api(libs.jsoup)
+    implementation(libs.apacheCommons.text)
+    implementation(libs.google.guava)
 
     //////////////////////////////
     // Kotlin library dependencies
     //////////////////////////////
 
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4")
-    api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0")
+    implementation(platform(libs.kotlinxCoroutines.bom))
+    api(libs.kotlinxCoroutines.core)
+    api(libs.kotlinxCoroutines.jdk8)
+
+    implementation(platform(libs.kotlinxSerialization.bom))
+    api(libs.kotlinxSerialization.json)
 
     ////////////////////
     // Ktor dependencies
     ////////////////////
-    api("io.ktor:ktor-server-jetty:2.1.2")
-    api("io.ktor:ktor-server-websockets:2.1.2")
-    api("io.ktor:ktor-server-default-headers:2.1.2")
-    api("io.ktor:ktor-server-compression:2.1.2")
-    api("io.ktor:ktor-server-caching-headers:2.1.2")
-    api("io.ktor:ktor-network-tls-certificates:2.1.2")
+    implementation(platform(libs.ktor.bom))
+    api(libs.ktorServer.jetty)
+    api(libs.ktorServer.websockets)
+    api(libs.ktorServer.defaultHeaders)
+    api(libs.ktorServer.compression)
+    api(libs.ktorServer.cachingHeaders)
+    api(libs.ktorNetwork.tlsCertificates)
 
-    api("io.mola.galimatias:galimatias:0.2.1")
+    api(libs.galimatias)
 
-    implementation("io.github.microutils:kotlin-logging:3.0.0")
+    implementation(libs.kotlinLogging)
 
     ///////////////////////////
     // Dependencies for testing
     ///////////////////////////
     // Pinned to 5.4.2 for now since there are issues with test discovery in 5.5.0
     // See: https://github.com/kotest/kotest/issues/3223
-    testApi(platform("io.kotest:kotest-bom:5.5.0"))
-    testApi(platform("org.junit:junit-bom:5.9.1"))
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junitJupiter.api)
+    testImplementation(libs.junitJupiter.engine)
 
-    testImplementation("io.kotest:kotest-runner-junit5")
-    testImplementation("io.kotest:kotest-assertions-core")
+    testImplementation(platform(libs.kotest.bom))
+    testImplementation(libs.kotest.runnerJunit5)
+    testImplementation(libs.kotest.assertionsCore)
 
-    testImplementation("ch.qos.logback:logback-classic:1.4.3")
+    testImplementation(libs.logbackClassic)
 
-    testImplementation("org.seleniumhq.selenium:selenium-opera-driver:4.4.0")
-    testImplementation("org.seleniumhq.selenium:selenium-chrome-driver:4.5.0")
-    testImplementation("org.seleniumhq.selenium:selenium-java:4.5.0")
-    testImplementation("io.github.bonigarcia:selenium-jupiter:4.3.1")
+    testImplementation(libs.selenium.operaDriver)
+    testImplementation(libs.selenium.chromeDriver)
+    testImplementation(libs.selenium.java)
+    testImplementation(libs.selenium.jupiter)
+}
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+tasks.test {
+    systemProperty("sel.jup.default.browser", System.getProperty("sel.jup.default.browser"))
 }
 
 tasks.dokkaHtml {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,15 +6,18 @@ plugins {
 }
 
 dependencies {
-    implementation(platform(kotlin("bom")))
+    implementation(platform(libs.kotlin.bom))
 
     // Import Gradle Plugins that will be used in the buildSrc pre-compiled script plugins, and any `build.gradle.kts`
     // files in the project.
     // Use their Maven coordinates (plus versions), not Gradle plugin IDs!
     // This should be the only place that Gradle plugin versions are defined, so they are aligned across all build scripts
 
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
-    implementation("org.jetbrains.kotlin:kotlin-serialization")
+    implementation(libs.gradlePlugin.kotlin)
+    implementation(libs.gradlePlugin.kotlinSerialization)
+    implementation(libs.gradlePlugin.dokka)
+    implementation(libs.gradlePlugin.shadow)
+    implementation(libs.gradlePlugin.gradleVersions)
 }
 
 val gradleJvmTarget = 11

--- a/buildSrc/repositories.settings.gradle.kts
+++ b/buildSrc/repositories.settings.gradle.kts
@@ -19,5 +19,10 @@ dependencyResolutionManagement {
 }
 
 fun RepositoryHandler.jitpack() {
-    maven("https://jitpack.io")
+    maven("https://jitpack.io") {
+        mavenContent {
+            // https://github.com/ben-manes/gradle-versions-plugin/issues/541#issuecomment-878461574
+            excludeGroup("com.github.ben-manes")
+        }
+    }
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,3 +1,12 @@
 rootProject.name = "buildSrc"
 
 apply(from = "./repositories.settings.gradle.kts")
+
+dependencyResolutionManagement {
+    @Suppress("UnstableApiUsage")
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+
 org.gradle.parallel=true
 org.gradle.caching=true
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,135 @@
+[versions]
+
+kotlin = "1.7.20"
+ktor = "2.1.2"
+jsoup = "1.15.3"
+kotlinxCoroutines = "1.6.4"
+kotlinSerialization = "1.4.0"
+kotlinDokka = "1.7.10"
+
+apacheCommons-text = "1.10.0"
+
+junit = "5.9.1"
+kotest = "5.5.0"
+
+[libraries]
+
+
+## Gradle plugins ##
+gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+gradlePlugin-kotlinSerialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
+gradlePlugin-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "kotlinDokka" }
+gradlePlugin-shadow = { module = "gradle.plugin.com.github.johnrengelman:shadow", version = "7.1.2" }
+gradlePlugin-gradleVersions = { module = "com.github.ben-manes:gradle-versions-plugin", version = "0.42.0" }
+
+
+## misc libs ##
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+
+apacheCommons-text = { module = "org.apache.commons:commons-text", version.ref = "apacheCommons-text" }
+google-guava = { module = "com.google.guava:guava", version = "31.1-jre" }
+galimatias = { module = "io.mola.galimatias:galimatias", version = "0.2.1" }
+
+
+## Kotlin ##
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version = "1.7.20" }
+
+
+## logging ##
+kotlinLogging = { module = "io.github.microutils:kotlin-logging", version = "3.0.0" }
+logbackClassic = { module = "ch.qos.logback:logback-classic", version = "1.4.3" }
+
+
+## Kotlinx Coroutines ##
+kotlinxCoroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinxCoroutines" }
+kotlinxCoroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
+kotlinxCoroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8" }
+
+
+## Kotlinx Serialization ##
+kotlinxSerialization-bom = { module = "org.jetbrains.kotlinx:kotlinx-serialization-bom", version.ref = "kotlinSerialization" }
+kotlinxSerialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core" }
+kotlinxSerialization-cbor = { module = "org.jetbrains.kotlinx:kotlinx-serialization-cbor" }
+kotlinxSerialization-hocon = { module = "org.jetbrains.kotlinx:kotlinx-serialization-hocon" }
+kotlinxSerialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json" }
+kotlinxSerialization-properties = { module = "org.jetbrains.kotlinx:kotlinx-serialization-properties" }
+kotlinxSerialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf" }
+kotlinxSerialization-jsonOkio = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-okio" }
+
+## Ktor ##
+ktor-bom = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
+
+ktorSerialization-kotlinxJson = { module = "io.ktor:ktor-serialization-kotlinx-json" }
+
+ktorClient-core = { module = "io.ktor:ktor-client-core" }
+ktorClient-auth = { module = "io.ktor:ktor-client-auth" }
+ktorClient-cio = { module = "io.ktor:ktor-client-cio" }
+ktorClient-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation" }
+ktorClient-encoding = { module = "io.ktor:ktor-client-encoding" }
+ktorClient-logging = { module = "io.ktor:ktor-client-logging" }
+ktorClient-resources = { module = "io.ktor:ktor-client-resources" }
+ktorClient-websockets = { module = "io.ktor:ktor-client-websockets" }
+
+ktorClient-testMock = { module = "io.ktor:ktor-client-mock" }
+
+ktorServer-core = { module = "io.ktor:ktor-server-core" }
+ktorServer-auth = { module = "io.ktor:ktor-server-auth" }
+ktorServer-authJwt = { module = "io.ktor:ktor-server-auth-jwt" }
+ktorServer-autoHeadResponse = { module = "io.ktor:ktor-server-auto-head-response" }
+ktorServer-cachingHeaders = { module = "io.ktor:ktor-server-caching-headers" }
+ktorServer-callId = { module = "io.ktor:ktor-server-call-id" }
+ktorServer-callLogging = { module = "io.ktor:ktor-server-call-logging" }
+ktorServer-compression = { module = "io.ktor:ktor-server-compression" }
+ktorServer-conditionalHeaders = { module = "io.ktor:ktor-server-conditional-headers" }
+ktorServer-contentNegotiaion = { module = "io.ktor:ktor-server-content-negotiation" }
+ktorServer-cors = { module = "io.ktor:ktor-server-cors" }
+ktorServer-dataConversion = { module = "io.ktor:ktor-server-data-conversion" }
+ktorServer-defaultHeaders = { module = "io.ktor:ktor-server-default-headers" }
+ktorServer-forwardedHeader = { module = "io.ktor:ktor-server-forwarded-header" }
+ktorServer-hsts = { module = "io.ktor:ktor-server-hsts" }
+ktorServer-httpRedirect = { module = "io.ktor:ktor-server-http-redirect" }
+ktorServer-netty = { module = "io.ktor:ktor-server-netty" }
+ktorServer-jetty = { module = "io.ktor:ktor-server-jetty" }
+ktorServer-cio = { module = "io.ktor:ktor-server-cio" }
+ktorServer-partialContent = { module = "io.ktor:ktor-server-partial-content" }
+ktorServer-resources = { module = "io.ktor:ktor-server-resources" }
+ktorServer-sessions = { module = "io.ktor:ktor-server-sessions" }
+ktorServer-statusPages = { module = "io.ktor:ktor-server-status-pages" }
+ktorServer-websockets = { module = "io.ktor:ktor-server-websockets" }
+
+ktorServer-testHost = { module = "io.ktor:ktor-server-test-host" }
+
+ktorNetwork-core = { module = "io.ktor:ktor-network" }
+ktorNetwork-tls = { module = "io.ktor:ktor-network-tls" }
+ktorNetwork-tlsCertificates = { module = "io.ktor:ktor-network-tls-certificates" }
+
+
+## kotest ##
+kotest-bom = { module = "io.kotest:kotest-bom", version.ref = "kotest" }
+kotest-assertionsCore = { module = "io.kotest:kotest-assertions-core" }
+kotest-datatest = { module = "io.kotest:kotest-framework-datatest" }
+kotest-assertionsJson = { module = "io.kotest:kotest-assertions-json" }
+kotest-property = { module = "io.kotest:kotest-property" }
+kotest-frameworkEngine = { module = "io.kotest:kotest-framework-engine" }
+kotest-runnerJunit5 = { module = "io.kotest:kotest-runner-junit5" }
+
+
+## selenium ##
+selenium-operaDriver = { module = "org.seleniumhq.selenium:selenium-opera-driver", version = "4.4.0" }
+selenium-chromeDriver = { module = "org.seleniumhq.selenium:selenium-chrome-driver", version = "4.5.0" }
+selenium-java = { module = "org.seleniumhq.selenium:selenium-java", version = "4.5.0" }
+selenium-jupiter = { module = "io.github.bonigarcia:selenium-jupiter", version = "4.3.1" }
+
+
+## junit ##
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junitJupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junitJupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
+
+
+[bundles]
+
+
+[plugins]
+# Prefer not to use the [plugins] block, because this block uses Gradle plugin IDs, and we prefer defining plugins in
+# buildSrc/build.gradle.kts using Maven coodinates.


### PR DESCRIPTION
Implements Gradle Version Catalog

https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format

This helps because now all the dependencies are defined in one place. There's a really swish auto-generated Kotlin API for accessing these libs.

Additionally

* I copied some of the `libs.versions.toml` config from my projects, so there's way more dependencies defined than what's required. That can be trimmed down if necessary .
* moved Gradle plugin versions into `buildSrc/build.gradle.kts` - now all plugins will have their versions aligned in a single place, even if more subprojects are added.
* changed the `testApi()` to `testImplementation()` for the Kotest and JUnit BOMs. Generally, I think it should be pretty rare to expose a dependency as an API depdency, let alone a platform dependency. Doing so is very opinionated, but perhaps that's the point of Kweb. 