### PR TITLE
Sonatype publishing: minor updates to maven-publish convention

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: "Tests"
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+
+  publish-SonatypeStaging:
+    runs-on: ubuntu-latest
+    needs: tests
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Build and run tests
+        run: ./gradlew publishAllPublicationsToSonatypeStagingRepository
+
+  publish-SonatypeProduction:
+    runs-on: ubuntu-latest
+    needs: tests
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Build and run tests
+        run: ./gradlew publishAllPublicationsToSonatypeProductionRepository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_call:
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,8 +19,6 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
     implementation("org.jetbrains.kotlin:kotlin-serialization")
-
-    implementation("io.github.gradle-nexus:publish-plugin:1.1.0")
 }
 
 val gradleJvmTarget = 11


### PR DESCRIPTION
Minor tweaks to the maven-publish script

tested locally by running `./gradlew publishAllPublicationsToMavenProjectLocalRepository` and checking `./build/maven-project-local`

* moved common MavenPublication config (POM, GAV, Javadoc stub) into non-specific configuration block, since this is always required for a Maven Central release.
* removed gradle-nexus.publish-plugin
* applied a Gradle signing plugin workaround https://github.com/gradle/gradle/issues/19903 so files are signed correctly.
* created a Workflow for publishing. I haven't tested it, it needs the secrets, but it should first run the tests, and then publish to staging/production (these steps are copy pasted, they could be streamlined to reduce the redundancy). It's manually triggered.


TODO

In the project's GitHub Secrets, define the following secrets:

* `signingKeyId`
* `signingKey`
* `signingPassword`
* `signingSecretKeyRingFile`
* `ossrhUsername`
* `ossrhPassword`

matching whatever is in your local `$GRADLE_USER_HOME/gradle.properties`.

And then make the appropriate environment variables available to a Gradle Action

* `ORG_GRADLE_PROJECT_signingKeyId`
* `ORG_GRADLE_PROJECT_signingKey`
* `ORG_GRADLE_PROJECT_signingPassword`
* `ORG_GRADLE_PROJECT_signingSecretKeyRingFile`
* `ORG_GRADLE_PROJECT_ossrhUsername`
* `ORG_GRADLE_PROJECT_ossrhPassword`

