### PR TITLE
Add initialValue support for select and textarea

### DIFF
--- a/api/kweb-core.api
+++ b/api/kweb-core.api
@@ -448,8 +448,8 @@ public final class kweb/PreludeKt {
 	public static final fun route (Lkweb/ElementCreator;Lkotlin/jvm/functions/Function1;)V
 	public static final fun section (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;)Lkweb/SectionElement;
 	public static synthetic fun section$default (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkweb/SectionElement;
-	public static final fun select (Lkweb/ElementCreator;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)Lkweb/SelectElement;
-	public static synthetic fun select$default (Lkweb/ElementCreator;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkweb/SelectElement;
+	public static final fun select (Lkweb/ElementCreator;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lkweb/SelectElement;
+	public static synthetic fun select$default (Lkweb/ElementCreator;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkweb/SelectElement;
 	public static final fun span (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;)Lkweb/SpanElement;
 	public static synthetic fun span$default (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkweb/SpanElement;
 	public static final fun subList (Lkweb/state/KVal;II)Lkweb/state/KVal;
@@ -460,9 +460,9 @@ public final class kweb/PreludeKt {
 	public static synthetic fun tbody$default (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkweb/TbodyElement;
 	public static final fun td (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;)Lkweb/TdElement;
 	public static synthetic fun td$default (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkweb/TdElement;
-	public static final fun textArea (Lkweb/ElementCreator;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)Lkweb/TextAreaElement;
+	public static final fun textArea (Lkweb/ElementCreator;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Lkweb/TextAreaElement;
 	public static final fun textArea (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;)Lkweb/TextAreaElement;
-	public static synthetic fun textArea$default (Lkweb/ElementCreator;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkweb/TextAreaElement;
+	public static synthetic fun textArea$default (Lkweb/ElementCreator;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkweb/TextAreaElement;
 	public static synthetic fun textArea$default (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkweb/TextAreaElement;
 	public static final fun th (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;)Lkweb/ThElement;
 	public static synthetic fun th$default (Lkweb/ElementCreator;Ljava/util/Map;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkweb/ThElement;

--- a/src/main/kotlin/kweb/prelude.kt
+++ b/src/main/kotlin/kweb/prelude.kt
@@ -409,6 +409,7 @@ class LinkElement(parent: Element) : Element(parent)
 fun ElementCreator<Element>.textArea(
     attributes: Map<String, JsonPrimitive> = emptyMap(),
     rows: Int? = null, cols: Int? = null, required: Boolean? = null,
+    initialValue: String? = null,
     new: (ElementCreator<TextAreaElement>.(TextAreaElement) -> Unit)? = null
 ): TextAreaElement {
     return TextAreaElement(
@@ -416,7 +417,7 @@ fun ElementCreator<Element>.textArea(
             "textArea", attributes.set("rows", JsonPrimitive(rows))
                 .set("cols", JsonPrimitive(cols))
                 .set("required", JsonPrimitive(required))
-        )
+        ), initialValue = initialValue
     ).also {
         if (new != null) new(ElementCreator(element = it, insertBefore = null), it)
     }
@@ -434,6 +435,7 @@ class SelectElement(parent: Element, initialValue: String? = null) :
 fun ElementCreator<Element>.select(
     attributes: Map<String, JsonPrimitive> = emptyMap(),
     name: String? = null, required: Boolean? = null,
+    initialValue: String? = null,
     new: (ElementCreator<SelectElement>.(SelectElement) -> Unit)? = null
 ): SelectElement {
     return SelectElement(
@@ -441,7 +443,7 @@ fun ElementCreator<Element>.select(
             "select", attributes
                 .set("name", JsonPrimitive(name))
                 .set("required", JsonPrimitive(required))
-        )
+        ), initialValue = initialValue
     ).also {
         if (new != null) new(ElementCreator(element = it, insertBefore = null), it)
     }

--- a/src/test/kotlin/kweb/SelectInitialValueTest.kt
+++ b/src/test/kotlin/kweb/SelectInitialValueTest.kt
@@ -1,0 +1,63 @@
+package kweb
+
+import io.github.bonigarcia.seljup.Arguments
+import io.github.bonigarcia.seljup.SeleniumJupiter
+import io.kotest.matchers.shouldBe
+import kweb.*
+import kweb.state.KVar
+import org.awaitility.Awaitility
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.support.ThreadGuard
+
+@ExtendWith(SeleniumJupiter::class)
+class SelectInitialValueTest(@Arguments("--headless") unprotectedDriver: ChromeDriver) {
+
+
+    //ThreadGuard.protect ensures that the ChromeDriver can only be called by the thread that created it
+    //This should make this test thread safe.
+    val driver = ThreadGuard.protect(unprotectedDriver)
+
+    companion object {
+        private lateinit var selectInitialValueTestApp: SelectInitialValueTestApp
+
+        @JvmStatic
+        @BeforeAll
+        fun setupServer() {
+            selectInitialValueTestApp = SelectInitialValueTestApp()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun tearDownServer() {
+            selectInitialValueTestApp.server.close()
+        }
+    }
+
+    @Test
+    fun mainTest() {
+        driver.get("http://localhost:7668/")
+        Awaitility.await().untilAsserted { selectInitialValueTestApp.selectValue.value shouldBe "cat" }
+    }
+}
+
+class SelectInitialValueTestApp {
+
+    internal lateinit var selectValue: KVar<String>
+
+    val server: Kweb = Kweb(port = 7668) {
+        doc.body {
+            val select = select(name = "pets", initialValue = "cat") {
+                option().set("value", "dog").text("Dog")
+                option().set("value", "cat").text("Cat")
+            }
+            selectValue = select.value
+            selectValue.addListener { old, new ->
+                println("$old -> $new")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/kweb/TextAreaInitialValueTest.kt
+++ b/src/test/kotlin/kweb/TextAreaInitialValueTest.kt
@@ -1,0 +1,60 @@
+package kweb
+
+import io.github.bonigarcia.seljup.Arguments
+import io.github.bonigarcia.seljup.SeleniumJupiter
+import io.kotest.matchers.shouldBe
+import kweb.*
+import kweb.state.KVar
+import org.awaitility.Awaitility
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.support.ThreadGuard
+
+@ExtendWith(SeleniumJupiter::class)
+class TextAreaInitialValueTest(@Arguments("--headless") unprotectedDriver: ChromeDriver) {
+
+
+    //ThreadGuard.protect ensures that the ChromeDriver can only be called by the thread that created it
+    //This should make this test thread safe.
+    private val driver = ThreadGuard.protect(unprotectedDriver)
+
+    companion object {
+        private lateinit var textareaInitialValueTestApp: TextAreaInitialValueTestApp
+
+        @JvmStatic
+        @BeforeAll
+        fun setupServer() {
+            textareaInitialValueTestApp = TextAreaInitialValueTestApp()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun tearDownServer() {
+            textareaInitialValueTestApp.server.close()
+        }
+    }
+
+    @Test
+    fun mainTest() {
+        driver.get("http://localhost:7668/")
+        Awaitility.await().untilAsserted { textareaInitialValueTestApp.textAreaValue.value shouldBe "cat" }
+    }
+}
+
+class TextAreaInitialValueTestApp {
+
+    internal lateinit var textAreaValue: KVar<String>
+
+    val server: Kweb = Kweb(port = 7668) {
+        doc.body {
+            val textArea = textArea(attributes = emptyMap(), initialValue = "cat")
+            textAreaValue = textArea.value
+            textAreaValue.addListener { old, new ->
+                println("$old -> $new")
+            }
+        }
+    }
+}


### PR DESCRIPTION
`ElementCreator<Element>.input` supports `initialValue`. But `select` and `textarea` doesn't support it.
If these elements are support `initialValue` field, I can write some code bit shorter.