### PR TITLE
Add CSSPlugin which enables the usage of custom CSS files

### DIFF
--- a/api/kweb-core.api
+++ b/api/kweb-core.api
@@ -1390,6 +1390,12 @@ public abstract class kweb/plugins/KwebPlugin {
 	public final fun getDependsOn ()Ljava/util/Set;
 }
 
+public final class kweb/plugins/css/CSSPlugin : kweb/plugins/KwebPlugin {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Set;)V
+	public fun decorate (Lorg/jsoup/nodes/Document;)V
+}
+
 public final class kweb/plugins/fomanticUI/FomanticUIClasses : kweb/AttributeBuilder {
 	public fun <init> ()V
 	public final fun getAccordion ()Lkweb/plugins/fomanticUI/FomanticUIClasses;

--- a/docs/src/style.md
+++ b/docs/src/style.md
@@ -1,22 +1,25 @@
 # CSS & Style
 
 Kweb can integrate easily with most CSS frameworks, particularly those
-that don't have a heavy reliance on JavaScript.
+that don't have a heavy reliance on JavaScript. Injecting custom CSS files 
+is also supported by using the CSSPlugin.
 
 <!-- toc -->
 
-## Fomantic UI
+## CSS Frameworks
+
+### Fomantic UI
 
 Kweb has out-of-the-box support for the excellent [Fomantic
 UI](https://fomantic-ui.com) framework, which helps create beautiful,
 responsive layouts using human-friendly HTML.
 
-### Getting started
+#### Getting started
 
 First tell Kweb to use the Fomantic UI plugin:
 
 ```kotlin
-{{#include ../../src/test/kotlin/kweb/docs/style.kt:plugin}}
+{{#include ../../src/test/kotlin/kweb/docs/style.kt:fomanticUIPlugin}}
 ```
 
 Now the plugin will add the Fomantic CSS and JavaScript code to your
@@ -41,14 +44,44 @@ This translates to the Kotlin:
 Take a look at the [Fomantic UI documentation](https://fomantic-ui.com)
 to see everything else it can do.
 
-### Example and Demo
+#### Example and Demo
 
 * [freenet.org](https://github.com/freenet/freenetorg-website/)
   A Kweb website built on Google Cloud Platform with Fomantic styling.
 
 
-## Other UI Frameworks
+### Other UI Frameworks
 
 Kweb is known to work well with a number of other CSS frameworks, including:
 
  * [Bulma](https://bulma.io/)
+
+## Custom CSS files
+The CSSPlugin can be used to inject custom CSS files into the website. To do so, 
+create your .css files in a folder located in src/main/resources and 
+add the CSSPlugin to the list of plugins.
+
+As an example, for the folder structure
+
+```
+├── src
+│  └─── main
+│      └─── resources
+│          └─── css
+│              └── test.css
+```
+
+the plugin definition would look like this:
+
+```kotlin
+{{#include ../../src/test/kotlin/kweb/docs/style.kt:CSSPlugin}}
+```
+
+You just need to specify the relative path to the folder inside src/main/resources
+and the files to include (either a single file name or a list of file names). 
+The files will then be served under /kweb_static/css and linked in the websites 
+HTML head tag:
+
+```html
+<link rel="stylesheet" type="text/css" href="/kweb_static/css/test.css">
+```

--- a/src/main/kotlin/kweb/plugins/css/CSSPlugin.kt
+++ b/src/main/kotlin/kweb/plugins/css/CSSPlugin.kt
@@ -1,0 +1,27 @@
+package kweb.plugins.css
+
+import kweb.plugins.KwebPlugin
+import kweb.plugins.staticFiles.ResourceFolder
+import kweb.plugins.staticFiles.StaticFilesPlugin
+import org.jsoup.nodes.Document
+
+/**
+ * This Plugin links custom stylesheets in the HTML head tag
+ *
+ * @property resourceFolder The relative path to the folder in the src/main/resources folder where the .css files are located
+ * @property fileNames The list of file names located in the resourceFolder which should be added to the website. Only files with suffix .css (case-insensitive) will be linked
+ *
+ * @author Cyneath
+ */
+class CSSPlugin(private val resourceFolder: String, private val fileNames: Set<String>) : KwebPlugin(dependsOn = setOf(StaticFilesPlugin(ResourceFolder(resourceFolder), "/kweb_static/css"))) {
+    constructor(resourceFolder: String, fileName: String) : this(resourceFolder, setOf(fileName))
+
+    override fun decorate(doc: Document) {
+        fileNames.filter { f -> f.endsWith(".css", true) }.forEach {
+            doc.head().appendElement("link")
+                .attr("rel", "stylesheet")
+                .attr("type", "text/css")
+                .attr("href", "/kweb_static/css/$it")
+        }
+    }
+}

--- a/src/test/kotlin/kweb/docs/style.kt
+++ b/src/test/kotlin/kweb/docs/style.kt
@@ -1,6 +1,8 @@
 package kweb.docs
 
-// ANCHOR: plugin
+import kweb.plugins.css.CSSPlugin
+
+// ANCHOR: fomanticUIPlugin
 import kweb.*
 import kweb.plugins.fomanticUI.*
 
@@ -9,7 +11,7 @@ fun main() {
         // ...
     }
 }
-// ANCHOR_END: plugin
+// ANCHOR_END: fomanticUIPlugin
 
 fun main2() {
     // ANCHOR: search
@@ -22,4 +24,13 @@ Kweb(port = 16097, plugins = listOf(fomanticUIPlugin)) {
     }
 }
     // ANCHOR_END: search
+}
+
+
+fun main3() {
+    // ANCHOR: CSSPlugin
+Kweb(port = 16097, plugins = listOf(CSSPlugin("css", "test.css"))) {
+    // ...
+}
+    // ANCHOR_END: CSSPlugin
 }


### PR DESCRIPTION
I created a new plugin for my own project to add custom CSS files. Maybe it's also useful for other people that do not want to use a CSS framework or which want to extend them with custom definitions.

I tried to extend the documentation, please rewrite as needed if it does not fit.

P.S.: I know that this is already possible to do by using the StaticFilesPlugin and adding the files to doc.head manually (by looking at the freenet example). This plugin should be seen as an easier way to do it. If you say that the plugin is not needed, maybe add a paragraph to the documentation which describes these steps as done in the freenet example