### PR TITLE
Fix "Received event callback with JsonNull" warning by adding a value the callback can read

### DIFF
--- a/src/main/kotlin/kweb/html/Window.kt
+++ b/src/main/kotlin/kweb/html/Window.kt
@@ -1,7 +1,7 @@
 package kweb.html
 
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonObject
 import kweb.*
 import kweb.html.events.Event
 import kweb.html.events.EventGenerator
@@ -37,9 +37,12 @@ class Window(override val browser: WebBrowser) : EventGenerator<Window> {
                 ${if (preventDefault) "event.preventDefault();" else ""}
                 callbackWs({}, $eventObject);
             });
-        """
+            return true;
+        """.trimIndent()
         browser.callJsFunctionWithCallback(js, callbackId, callback = { payload ->
-            callback.invoke(payload)
+            if (payload is JsonObject) {
+                callback.invoke(payload)
+            }
         }, eventName.json, callbackId.json)
         return this
     }


### PR DESCRIPTION
## Summary

This commit fixes the occasional "Received event callback with JsonNull where data is expected" warning from the logs.
This was the same bug that was (mostly) fixed in 12f34aed

## Breakdown

The log line is emitted in OnReceiver.kt#36, when a callback is received with no discernible callback data.
These callbacks are sent as part of Websocket messages. To even arrive at this code it means we received a valid callback,
with a valid callbackId attached. Let's take one step back, to see how we got here.

The websocket messages that arrive to the backend, are sent, of course, from the frontend.
In particular there is a function on the frontend (`handleInboundMessage()`), that executes arbitrary
functions, and sends their results, together with the callbackId back to the server, via Websockets.
Let's take one more step back: Who fired `handleInboundMessage`?

<img src="https://image.tmdb.org/t/p/original/eshnZ90NTItq40jogl5ukEODPKM.jpg" width="50%">

This `handleInboundMessage` was fired from the server. It's declared over at Window.kt#35 and originally
built on WebBrowser.kt#318. It's basically an event listener that listens for URL changes in the client,
and tracks them as user-iniated changes. The callback expects it to provide a value, but since it just
creates an event listener, it doesn't.

To recap, the workflow is like this:
Server sends a WS message with a callbackId and a function to run (the function is adding a window listener) ->
Client runs `handleInboundMessage`, executes the function, produces null result and sends back `{callbackId: THE_ID}`
This doesn't include any data in the callback ->
Server reads the inbound WS message, and logs a warning because it doesn't have data

## How can someone replicate this?

Easy, this shows up everywhere, including on the TodoApp.kt example in tests.
Just run it and look at the output.

## How is this fixed?

Easy. Just like in 12f34aed, we can just add a return true so that the callback is happy.
The TODOs seem to have considered adding an extra param to the callback, but to me that's a bit overkill,
 and not quite the expected design for a callback.
